### PR TITLE
[Posts] WebP prompts, Reforge "stealth" data, improve PNG chunks

### DIFF
--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -225,14 +225,18 @@ export default class PostsShowToolbar {
   // Prompt button
   initPromptButton () {
     let loaded = false;
-    $(".ptbr-prompt-button").on("click", () => {
+    const button = $(".ptbr-prompt-button");
+    button.on("click", () => {
       if (loaded) {
         $("#gen-info-container").toggleClass("hidden");
         return;
       }
       loaded = true;
+      button.attr("pending", "true");
       GenInfo.loadAndShow().catch((err) => {
         console.warn("GenInfo: Failed to extract metadata", err);
+      }).finally(() => {
+        button.attr("pending", "false");
       });
     });
   }

--- a/app/javascript/src/js/pages/posts/show/gen_info.js
+++ b/app/javascript/src/js/pages/posts/show/gen_info.js
@@ -2,68 +2,143 @@
  * GenInfo Extractor
  *
  * Extracts generation parameters from image files:
- * - PNG: tEXt chunks (pnginfo)
- * - JPEG: EXIF UserComment (piexif unicode encoding)
- *
- * Uses HTTP Range requests to fetch only the header portion of the file.
+ * - PNG: tEXt, zTXt and iTxt chunks
+ * - WebP: EXIF UserComment
+ * - JPEG: EXIF UserComment
+ * - Reforge "stealth info" in PNG or WEBP colour or alpha channels
  */
 
 const GenInfo = {};
 
-// Maximum bytes to fetch (32KB should cover metadata before image data)
-const MAX_FETCH_BYTES = 32 * 1024;
-
-// PNG signature: 0x89 P N G \r \n 0x1A \n
-const PNG_SIGNATURE = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-
-// EXIF constants
-const EXIF_IFD_TAG = 0x8769;
-const USER_COMMENT_TAG = 0x9286;
+GenInfo.decompress = async (data, encoding) => {
+  return new Response(new Blob([data]).stream().pipeThrough(
+    new DecompressionStream(encoding))).arrayBuffer();
+};
 
 /**
  * Parse PNG chunks from an ArrayBuffer
- * Stops when it hits IDAT (image data) since metadata comes before that
  */
-GenInfo.parsePngChunks = function (buffer) {
+GenInfo.parsePngChunks = async function (buffer) {
   const view = new DataView(buffer);
-  const chunks = [];
 
-  // Verify PNG signature
+  // PNG signature: 0x89 P N G \r \n 0x1A \n
+  const PNG_SIGNATURE = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
   for (let i = 0; i < PNG_SIGNATURE.length; i++) {
     if (view.getUint8(i) !== PNG_SIGNATURE[i]) {
-      throw new Error("Not a valid PNG file");
+      return [];
     }
   }
 
-  let offset = 8; // Skip signature
+  let offset = PNG_SIGNATURE.length; // Skip signature
 
+  const latin1 = new TextDecoder("latin1");
+  const utf8 = new TextDecoder("utf-8");
+
+  const info = [];
   while (offset < buffer.byteLength - 12) { // Need at least 12 bytes for a chunk
     const length = view.getUint32(offset);
     const typeBytes = new Uint8Array(buffer, offset + 4, 4);
     const type = String.fromCharCode(...typeBytes);
 
-    // Stop at IDAT - we've got all the metadata
-    if (type === "IDAT") {
-      break;
-    }
+    if (type === "tEXt" || type === "zTXt" || type === "iTXt") {
+      let chunk = new Uint8Array(buffer, offset + 8, Math.min(length, buffer.byteLength - offset - 12));
 
-    // Extract tEXt chunks
-    if (type === "tEXt") {
-      const data = new Uint8Array(buffer, offset + 8, Math.min(length, buffer.byteLength - offset - 12));
-      const nullIndex = data.indexOf(0);
-      if (nullIndex !== -1) {
-        chunks.push({
-          keyword: GenInfo.decodeText(data.slice(0, nullIndex)),
-          text: GenInfo.decodeText(data.slice(nullIndex + 1)),
-        });
-      }
+      let nullIndex = chunk.indexOf(0);
+      let keyword = latin1.decode(chunk.subarray(0, nullIndex));
+      chunk = chunk.subarray(nullIndex + 1);
+
+      let textDecoder = latin1;
+      if (type === "iTXt") {
+        const isCompressed = chunk[0];
+        // Next byte is the compression type, it's always 0 for DEFLATE
+        // Next bytes to null terminator are for the language tag we don't care about
+        nullIndex = chunk.indexOf(0, 2);
+        chunk = chunk.subarray(nullIndex + 1);
+
+        // Next bytes to null terminator is the translated keyword, we'll use it
+        nullIndex = chunk.indexOf(0);
+        const translatedKeyword = utf8.decode(chunk.subarray(0, nullIndex));
+        if (translatedKeyword) {
+          keyword += ` (${translatedKeyword})`;
+        }
+
+        // After that is the compressed text
+        chunk = chunk.subarray(nullIndex + 1);
+        if (isCompressed) {
+          chunk = await GenInfo.decompress(chunk, "deflate");
+        }
+
+        textDecoder = utf8;
+      } else if (type === "zTXt") {
+        // Next byte is the compression type, it's always 0 for DEFLATE
+        chunk = chunk.subarray(1);
+        // After that is the compressed text
+        chunk = await GenInfo.decompress(chunk, "deflate");
+      } // else tEXt, no special handling
+
+      info.push({
+        keyword: keyword,
+        text: textDecoder.decode(chunk),
+      });
     }
 
     // Move to next chunk: 4 (length) + 4 (type) + length (data) + 4 (CRC)
     offset += 12 + length;
   }
 
-  return chunks;
+  return info;
+};
+
+/**
+ * Parse WebP chunks from an ArrayBuffer
+ * https://developers.google.com/speed/webp/docs/riff_container
+ */
+GenInfo.parseWebPChunks = function (buffer) {
+  const view = new DataView(buffer);
+
+  // WebP header: RIFF <int size> WEBP
+  const RIFF_SIGNATURE = [0x52, 0x49, 0x46, 0x46];
+  for (let i = 0; i < RIFF_SIGNATURE.length; i++) {
+    if (view.getUint8(i) !== RIFF_SIGNATURE[i]) {
+      return [];
+    }
+  }
+  let offset = RIFF_SIGNATURE.length;
+
+  const fileSize = view.getUint32(offset, true);
+  offset += 4;
+
+  const WEBP_SIGNATURE = [0x57, 0x45, 0x42, 0x50];
+  for (let i = 0; i < WEBP_SIGNATURE.length; i++) {
+    if (view.getUint8(offset + i) !== WEBP_SIGNATURE[i]) {
+      return [];
+    }
+  }
+  offset += WEBP_SIGNATURE.length;
+
+  // List of RIFF chunks (fourCC size body)
+  let info = [];
+  while (offset < fileSize - 8) { // Need at least 8 bytes for a chunk
+    const fourCC = view.getUint32(offset, true);
+    const size = view.getUint32(offset + 4, true);
+    const name = String.fromCharCode(
+      fourCC & 0xFF,
+      (fourCC >> 8) & 0xFF,
+      (fourCC >> 16) & 0xFF,
+      (fourCC >> 24) & 0xFF,
+    );
+    console.log(name);
+    if (name == "EXIF") {
+      info = info.concat(GenInfo.parseExifUserComment(buffer, offset + 8, size));
+    }
+
+    // Spec: If Chunk Size is odd, a single padding byte -- which MUST be 0 to conform with RIFF -- is added.
+    const padding = size & 1;
+    // Move to next chunk: 4 (fourCC) + 4 (size) + padding + size
+    offset += 8 + size + padding;
+  }
+
+  return info;
 };
 
 /**
@@ -76,8 +151,10 @@ GenInfo.parseJpegUserComment = function (buffer) {
 
   // Verify JPEG SOI marker
   if (view.getUint16(0) !== 0xFFD8) {
-    throw new Error("Not a valid JPEG file");
+    return [];
   }
+
+  let info = [];
 
   // Find APP1 (Exif) marker
   let offset = 2;
@@ -88,36 +165,40 @@ GenInfo.parseJpegUserComment = function (buffer) {
       const segmentStart = offset + 4;
 
       // Check for "Exif\0\0" header
-      if (
-        view.getUint32(segmentStart) === 0x45786966 // "Exif"
-        && view.getUint16(segmentStart + 4) === 0x0000
-      ) {
-        return GenInfo.parseExifUserComment(buffer, segmentStart + 6, segmentLength - 2);
+      if (view.getUint32(segmentStart) === 0x45786966 // "Exif"
+        && view.getUint16(segmentStart + 4) === 0x0000) {
+        info = info.concat(GenInfo.parseExifUserComment(buffer, segmentStart + 6, segmentLength - 2));
       }
     }
 
     // Not APP1 or not Exif — skip this segment
-    if ((marker & 0xFF00) !== 0xFF00) break; // Not a valid marker
+    if ((marker & 0xFF00) !== 0xFF00) {
+      break; // Not a valid marker
+    }
+
     const len = view.getUint16(offset + 2);
     offset += 2 + len;
   }
 
-  return [];
+  return info;
 };
 
 /**
  * Parse EXIF IFDs to extract UserComment.
- * tiffStart is the absolute offset of the TIFF header ("II" or "MM") in the buffer.
  */
-GenInfo.parseExifUserComment = function (buffer, tiffStart) {
-  const view = new DataView(buffer);
+GenInfo.parseExifUserComment = function (buffer, start, length) {
+  let view = new DataView(buffer, start, length);
+
+  // EXIF constants
+  const EXIF_IFD_TAG = 0x8769;
+  const USER_COMMENT_TAG = 0x9286;
 
   // Read byte order
-  const byteOrder = view.getUint16(tiffStart);
+  const byteOrder = view.getUint16(0);
   const le = byteOrder === 0x4949; // "II" = little-endian
 
-  const getU16 = (off) => view.getUint16(tiffStart + off, le);
-  const getU32 = (off) => view.getUint32(tiffStart + off, le);
+  const getU16 = off => view.getUint16(off, le);
+  const getU32 = off => view.getUint32(off, le);
 
   // IFD0 offset (from TIFF header)
   const ifd0Offset = getU32(4);
@@ -133,7 +214,11 @@ GenInfo.parseExifUserComment = function (buffer, tiffStart) {
     }
   }
 
-  if (exifIfdOffset === null) return [];
+  if (exifIfdOffset === null) {
+    return [];
+  }
+
+  const info = [];
 
   // Walk ExifIFD to find UserComment
   const exifEntries = getU16(exifIfdOffset);
@@ -143,59 +228,289 @@ GenInfo.parseExifUserComment = function (buffer, tiffStart) {
       const count = getU32(entryOff + 4);
       // Value offset (UNDEFINED type, count > 4 means offset is stored)
       const valueOffset = count > 4 ? getU32(entryOff + 8) : entryOff + 8;
-      const commentBytes = new Uint8Array(buffer, tiffStart + valueOffset, Math.min(count, buffer.byteLength - tiffStart - valueOffset));
+      const commentBytes = new Uint8Array(buffer, view.byteOffset + valueOffset, Math.min(
+        count, buffer.byteLength - view.byteOffset - valueOffset));
 
       // First 8 bytes are charset identifier
-      const charset = String.fromCharCode(...commentBytes.slice(0, 8)).replace(/\0/g, "");
-      const payload = commentBytes.slice(8);
-
-      let text;
-      if (charset === "UNICODE") {
-        text = new TextDecoder("utf-16be").decode(payload);
-      } else {
-        text = GenInfo.decodeText(payload);
+      const charset = String.fromCharCode(...commentBytes.subarray(0, 8)).replace(/\0/g, "");
+      let encoding;
+      switch (charset) {
+        case "UNICODE":
+          encoding = "utf-16be";
+          break;
+        case "JIS":
+          encoding = "shift-jis";
+          break;
+        case "ASCII":
+          encoding = "ascii";
+          break;
+        default: // UNDEFINED: try UTF-8
+          encoding = "utf-8";
+          break;
       }
 
+      const payload = commentBytes.subarray(8);
+      const text = new TextDecoder(encoding).decode(payload);
       if (text) {
-        return [{ keyword: "parameters", text }];
+        info.push({ keyword: "EXIF UserComment", text: text });
       }
     }
   }
 
-  return [];
+  return info;
 };
 
 /**
- * Decode bytes to string
+ * See: https://github.com/Panchovix/stable-diffusion-webui-reForge/blob/739b2e1d9ab63160eaff9c8f73172c8da68424e1/modules/stealth_infotext.py#L57
  */
-GenInfo.decodeText = function (bytes) {
-  try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  } catch {
-    return new TextDecoder("latin1").decode(bytes);
+GenInfo.decodeStealthData = async function (blob) {
+  const bitmap = await createImageBitmap(blob, {
+    colorSpaceConversion: "none",
+  });
+
+  let pixels = null;
+  const getPixels = forPixelCount => {
+    const height = Math.min(forPixelCount, bitmap.height);
+    const width = Math.min(Math.ceil(forPixelCount / height), bitmap.width);
+    if (pixels && pixels.width >= width) {
+      return pixels;
+    }
+
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext("2d");
+    context.drawImage(bitmap, 0, 0, width, height, 0, 0, width, height);
+    return context.getImageData(0, 0, width, height);
+  };
+
+  const signatureAlphaPlain = "stealth_pnginfo";
+  const signatureAlphaCompressed = "stealth_pngcomp";
+  const signatureRgbPlain = "stealth_rgbinfo";
+  const signatureRgbCompressed = "stealth_rgbcomp";
+  const signatureLength = signatureAlphaPlain.length;
+
+  const lengthLength = 4; // Length of the length field
+
+  const decoder = new TextDecoder("utf-8");
+
+  // Start with big enough for signatures
+  let rgbBytes = new Uint8Array(signatureLength);
+  let rgbByteCount = 0;
+  let alphaBytes = new Uint8Array(signatureLength);
+  let alphaByteCount = 0;
+
+  const State = Object.freeze({
+    SIGNATURE: Symbol("State.SIGNATURE"),
+    LENGTH: Symbol("State.LENGTH"),
+    PAYLOAD: Symbol("State.PAYLOAD"),
+    FINISHED: Symbol("State.FINISHED"),
+  });
+
+  let rgbState = State.SIGNATURE;
+  let alphaState = State.SIGNATURE;
+
+  let rgbSignature = "";
+  let alphaSignature = "";
+
+  let rgbPayloadCompressed = false;
+  let alphaPayloadCompressed = false;
+
+  let rgbPayloadLength = 0;
+  let alphaPayloadLength = 0;
+
+  const decodePayloads = async () => {
+    const payloads = [];
+    if (rgbState === State.FINISHED && rgbByteCount > 0) {
+      if (rgbPayloadCompressed) {
+        rgbBytes = await GenInfo.decompress(rgbBytes, "gzip");
+      }
+      const text = decoder.decode(rgbBytes);
+      payloads.push({keyword: "RGB encoded", text: text});
+    }
+    if (alphaState === State.FINISHED && alphaByteCount > 0) {
+      if (alphaPayloadCompressed) {
+        alphaBytes = await GenInfo.decompress(alphaBytes, "gzip");
+      }
+      const text = decoder.decode(alphaBytes);
+      payloads.push({keyword: "Alpha encoded", text: text});
+    }
+    return payloads;
+  };
+
+  // 1 bit per pixel for alpha
+  const headerPixelCount = (signatureLength + 4) * 8;
+  pixels = getPixels(headerPixelCount);
+
+  let rgbBuffer = 0;
+  let rgbBitCount = 0;
+  let alphaBuffer = 0;
+  let alphaBitCount = 0;
+  for (let x = 0; x < pixels.width; x++) {
+    for (let y = 0; y < pixels.height; y++) {
+      const index = ((y * pixels.width) + x) * 4;
+
+      if (rgbState !== State.FINISHED) {
+        const r = pixels.data[index + 0];
+        const g = pixels.data[index + 1];
+        const b = pixels.data[index + 2];
+        rgbBuffer <<= 1;
+        rgbBuffer |= r & 1;
+        rgbBuffer <<= 1;
+        rgbBuffer |= g & 1;
+        rgbBuffer <<= 1;
+        rgbBuffer |= b & 1;
+        rgbBitCount += 3;
+        if (rgbBitCount === 24) {
+          rgbBytes[rgbByteCount++] = (rgbBuffer >> 16) & 0xFF;
+          rgbBytes[rgbByteCount++] = (rgbBuffer >> 8) & 0xFF;
+          rgbBytes[rgbByteCount++] = (rgbBuffer >> 0) & 0xFF;
+          rgbBuffer = 0;
+          rgbBitCount = 0;
+        }
+      }
+
+      switch (rgbState) {
+        case State.SIGNATURE: {
+          if (rgbByteCount === signatureLength) {
+            rgbSignature = decoder.decode(rgbBytes.subarray(0, signatureLength));
+            if (rgbSignature === signatureRgbCompressed) {
+              rgbPayloadCompressed = true;
+            }
+            rgbByteCount = 0;
+            if (rgbPayloadCompressed || rgbSignature === signatureRgbPlain) {
+              rgbState = State.LENGTH;
+            } else {
+              rgbState = State.FINISHED;
+            }
+          }
+          break;
+        }
+        case State.LENGTH: {
+          if (rgbByteCount >= lengthLength) {
+            const payloadBitCount = new DataView(rgbBytes.buffer).getInt32(0);
+            const unusedBytes = rgbBytes.slice(lengthLength, rgbByteCount);
+            const maxBitCount = bitmap.width * bitmap.height * 3;
+            rgbPayloadLength = Math.max(unusedBytes.length, Math.floor(Math.min(payloadBitCount, maxBitCount) / 8));
+            rgbByteCount = 0;
+            if (rgbPayloadLength > 0) {
+              // Round up next multiple of 3
+              rgbBytes = new Uint8Array(Math.ceil(rgbPayloadLength / 3) * 3);
+              rgbBytes.set(unusedBytes);
+              rgbByteCount = unusedBytes.length;
+              rgbState = State.PAYLOAD;
+              pixels = getPixels(headerPixelCount + (payloadBitCount / 3));
+            } else {
+              rgbState = State.FINISHED;
+            }
+          }
+          break;
+        }
+        case State.PAYLOAD: {
+          if (rgbByteCount >= rgbPayloadLength) {
+            rgbBytes = rgbBytes.subarray(0, rgbPayloadLength);
+            rgbState = State.FINISHED;
+          }
+          break;
+        }
+      }
+
+      if (alphaState !== State.FINISHED) {
+        const a = pixels.data[index + 3];
+        alphaBuffer <<= 1;
+        alphaBuffer |= a & 1;
+        alphaBitCount += 1;
+        if (alphaBitCount === 8) {
+          alphaBytes[alphaByteCount++] = (alphaBuffer >> 0) & 0xFF;
+          alphaBuffer = 0;
+          alphaBitCount = 0;
+        }
+      }
+
+      switch (alphaState) {
+        case State.SIGNATURE: {
+          if (alphaByteCount === signatureLength) {
+            alphaSignature = decoder.decode(alphaBytes.subarray(0, signatureLength));
+            if (alphaSignature === signatureAlphaCompressed) {
+              alphaPayloadCompressed = true;
+            }
+            alphaByteCount = 0;
+            if (alphaPayloadCompressed || alphaSignature === signatureAlphaPlain) {
+              alphaState = State.LENGTH;
+            } else {
+              alphaState = State.FINISHED;
+            }
+          }
+          break;
+        }
+        case State.LENGTH: {
+          if (alphaByteCount === lengthLength) {
+            const payloadBitCount = new DataView(alphaBytes.buffer).getInt32(0);
+            const maxBitCount = bitmap.width * bitmap.height;
+            alphaPayloadLength = Math.floor(Math.min(payloadBitCount, maxBitCount) / 8);
+            alphaByteCount = 0;
+            if (alphaPayloadLength > 0) {
+              alphaBytes = new Uint8Array(alphaPayloadLength);
+              alphaState = State.PAYLOAD;
+              pixels = getPixels(headerPixelCount + payloadBitCount);
+            } else {
+              alphaState = State.FINISHED;
+            }
+          }
+          break;
+        }
+        case State.PAYLOAD: {
+          if (alphaByteCount === alphaPayloadLength) {
+            alphaState = State.FINISHED;
+          }
+          break;
+        }
+      }
+
+      if (rgbState === State.FINISHED && alphaState === State.FINISHED) {
+        return await decodePayloads();
+      }
+    }
   }
+
+  return await decodePayloads();
 };
 
 /**
  * Fetch image metadata using Range request
  */
 GenInfo.fetchMetadata = async function (url, fileExt) {
-  const response = await fetch(url, {
-    headers: {
-      "Range": `bytes=0-${MAX_FETCH_BYTES - 1}`,
-    },
-  });
-
+  const response = await fetch(url, { cache: "force-cache" });
   if (!response.ok) {
-    throw new Error(`Failed to fetch: ${response.status}`);
+    console.error(`Failed to fetch image: ${response.status}`);
+    return [];
   }
 
-  const buffer = await response.arrayBuffer();
+  const blob = await response.blob();
 
-  if (fileExt === "png") {
-    return GenInfo.parsePngChunks(buffer);
+  let stealthInfo = [];
+  if (fileExt === "png" || fileExt === "webp") {
+    try {
+      stealthInfo = await GenInfo.decodeStealthData(blob);
+    } catch (exception) {
+      console.error(exception);
+    }
   }
-  return GenInfo.parseJpegUserComment(buffer);
+
+  try {
+    const buffer = await blob.arrayBuffer();
+    switch (fileExt) {
+      case "png":
+        return stealthInfo.concat(await GenInfo.parsePngChunks(buffer));
+      case "jpg":
+      case "jpeg":
+        return stealthInfo.concat(GenInfo.parseJpegUserComment(buffer));
+      case "webp":
+        return stealthInfo.concat(GenInfo.parseWebPChunks(buffer));
+    }
+  } catch (exception) {
+    console.error(exception);
+  }
+
+  return [];
 };
 
 /**
@@ -228,10 +543,9 @@ GenInfo.getOriginalUrl = function () {
   if (!$container.length) return null;
 
   const fileExt = $container.data("file-ext");
-  if (!["png", "jpg", "jpeg"].includes(fileExt)) return null;
+  if (!["png", "jpg", "jpeg", "webp"].includes(fileExt)) return null;
 
-  const postData = $container.data("post");
-  const url = postData?.file?.url || null;
+  const url = $container.data("file-url");
   if (!url) return null;
 
   return { url, fileExt };

--- a/app/javascript/src/js/pages/posts/show/gen_info.js
+++ b/app/javascript/src/js/pages/posts/show/gen_info.js
@@ -118,7 +118,7 @@ GenInfo.parseWebPChunks = function (buffer) {
 
   // List of RIFF chunks (fourCC size body)
   let info = [];
-  while (offset < fileSize - 8) { // Need at least 8 bytes for a chunk
+  while (offset < Math.min(fileSize, buffer.byteLength) - 8) { // Need at least 8 bytes for a chunk
     const fourCC = view.getUint32(offset, true);
     const size = view.getUint32(offset + 4, true);
     const name = String.fromCharCode(
@@ -127,7 +127,6 @@ GenInfo.parseWebPChunks = function (buffer) {
       (fourCC >> 16) & 0xFF,
       (fourCC >> 24) & 0xFF,
     );
-    console.log(name);
     if (name == "EXIF") {
       info = info.concat(GenInfo.parseExifUserComment(buffer, offset + 8, size));
     }

--- a/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
@@ -242,27 +242,13 @@
 }
 
 
-// Prompt toggle
-#ptbr-wrapper .ptbr-prompt {
-  display: none;
-  @include window-larger-than(40rem) { display: flex; }
-}
-
-#ptbr-wrapper .ptbr-prompt-button {
-  font-family: "Roboto", Verdana, Geneva, sans-serif;
-}
-
-
-// Download button
-#ptbr-wrapper .ptbr-etc-download {
-  min-width: 6rem;
-  align-items: center;
-
+@mixin ptbr-wait-spinner {
   svg {
     display: none;
     height: 1rem;
     width: 1rem;
     animation: spin-animation ease-in-out 1s infinite;
+    position: absolute;
   }
 
   span {
@@ -271,13 +257,35 @@
 
   &[pending="true"] {
     svg { display: inline; }
-    span { display: none; }
+    span { visibility: hidden; }
   }
-  
+
   @keyframes spin-animation {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
   }
+}
+
+
+// Prompt toggle
+#ptbr-wrapper .ptbr-prompt {
+  display: none;
+  @include window-larger-than(40rem) { display: flex; }
+}
+
+#ptbr-wrapper .ptbr-prompt-button {
+  font-family: "Roboto", Verdana, Geneva, sans-serif;
+
+  @include ptbr-wait-spinner
+}
+
+
+// Download button
+#ptbr-wrapper .ptbr-etc-download {
+  min-width: 6rem;
+  align-items: center;
+
+  @include ptbr-wait-spinner
 }
 
 

--- a/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
@@ -276,7 +276,7 @@
 #ptbr-wrapper .ptbr-prompt-button {
   font-family: "Roboto", Verdana, Geneva, sans-serif;
 
-  @include ptbr-wait-spinner
+  @include ptbr-wait-spinner;
 }
 
 
@@ -285,7 +285,7 @@
   min-width: 6rem;
   align-items: center;
 
-  @include ptbr-wait-spinner
+  @include ptbr-wait-spinner;
 }
 
 

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -122,9 +122,12 @@
   </div>
 <% end %>
 
-<% if @post.file_ext.in?(%w[png jpg jpeg]) %>
+<% if @post.file_ext.in?(%w[png jpg jpeg webp]) %>
   <div class="ptbr-prompt">
-    <button class="st-button kinetic ptbr-prompt-button">Prompt</button>
+    <button class="st-button kinetic ptbr-prompt-button">
+      <%= svg_icon(:hexagon) %>
+      <span>Prompt</span>
+    </button>
   </div>
 <% end %>
 
@@ -153,8 +156,11 @@
         <span>Download</span>
       </a>
       <button class="st-button ptbr-share-button" data-hotkey="share">Share</button>
-      <% if @post.file_ext.in?(%w[png jpg jpeg]) %>
-        <button class="st-button ptbr-prompt-button">Prompt</button>
+      <% if @post.file_ext.in?(%w[png jpg jpeg webp]) %>
+        <button class="st-button ptbr-prompt-button">
+        <%= svg_icon(:hexagon) %>
+        <span>Prompt</span>
+        </button>
       <% end %>
       <% if CurrentUser.is_member? %>
         <button class="st-button ptbr-etc-pool add-to-pool" data-hotkey="add-to-pool">Add to Pool</button>

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -158,8 +158,8 @@
       <button class="st-button ptbr-share-button" data-hotkey="share">Share</button>
       <% if @post.file_ext.in?(%w[png jpg jpeg webp]) %>
         <button class="st-button ptbr-prompt-button">
-        <%= svg_icon(:hexagon) %>
-        <span>Prompt</span>
+          <%= svg_icon(:hexagon) %>
+          <span>Prompt</span>
         </button>
       <% end %>
       <% if CurrentUser.is_member? %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -38,7 +38,7 @@
         <h3>Related</h3>
         <%= render "posts/partials/show/sidebar/related", :post => @post %>
       </section>
-      
+
       <div class="go-up"><button type="button" class="st-button kinetic" title="Scroll to top" aria-label="Scroll to top"><%= svg_icon(:corner_right_up) %></button></div>
     </div>
 
@@ -85,7 +85,7 @@
 
       <%= render "posts/partials/show/content/toolbar", post: @post %>
 
-      <% if @post.file_ext.in?(%w[png jpg jpeg]) %>
+      <% if @post.file_ext.in?(%w[png jpg jpeg webp]) %>
         <div id="gen-info-container" class="styled-dtext"></div>
       <% end %>
 


### PR DESCRIPTION
- WebP prompts from EXIF UserComment
- PNG support for zTXt and iTxt chunks
- Reforge "stealth" prompts encoded in RGB or alpha channel
- Parse whole image file for metadata since it can be after the image chunks (recommended by some specs)
- Replace the HTTP range fetch by a normal fetch, because it actually bypasses the browser cache so it's more expensive.
- Add a loading spinner for the prompt, since massive images can take a while to scan
- Misc cleanups and spec adherence improvements