### PR TITLE
[PostFlags] Disable automatic AI flagging

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,7 +32,7 @@ class Post < ApplicationRecord
   validate :updater_can_change_rating
   before_save :update_tag_post_counts, if: :should_process_tags?
   before_save :set_tag_counts, if: :should_process_tags?
-  after_create :check_for_ai_content, if: -> { Setting.automatic_ai_check? }
+  # removed for e6ai: after_create :check_for_ai_content
   after_save :create_post_events
   after_save :create_version
   after_save :update_parent_on_save

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -42,7 +42,8 @@ class Setting < RailsSettings::Base
   end
 
   scope :ai_flag do
-    field :automatic_ai_check, type: :boolean, default: true
-    field :ai_flag_reason, type: :string, default: "uploading_guidelines"
+    # defaults modified for e6ai
+    field :automatic_ai_check, type: :boolean, default: false
+    field :ai_flag_reason, type: :string, default: ""
   end
 end

--- a/app/views/post_flag_reasons/index.html.erb
+++ b/app/views/post_flag_reasons/index.html.erb
@@ -22,25 +22,7 @@
       </tbody>
     </table>
 
-    <%= custom_form_for(:ai_flag_reason, url: set_ai_flag_reason_post_flag_reasons_path, method: :post, local: true, id: "ai-flag-reason-form", class: "simple_form") do |f| %>
-      <div class="input">
-        <%= f.label :automatic_ai_check, "Enable Automatic AI Check" %>
-        <%= f.check_box :automatic_ai_check, { checked: Setting.automatic_ai_check? }, "true", "false" %>
-      </div>
-      <div class="input">
-        <%= f.label :reason, "AI Flag Reason" %>
-        <% usable_flag_reasons = PostFlagReason.for_radio.reject(&:needs_parent_id?) %>
-        <%= f.select :reason,
-          options_for_select(
-            usable_flag_reasons.map { |reason| [reason.name, reason.name] },
-            selected: usable_flag_reasons.any? { |reason| reason.name == Setting.ai_flag_reason } ?
-              Setting.ai_flag_reason : nil),
-          {} %>
-      </div>
-      <div class="actions">
-        <%= f.submit "Save", class: "st-button submit" %>
-      </div>
-    <% end %>
+    <%# removed for e6ai: ai-flag-reason-form %>
   </div>
 </div>
 


### PR DESCRIPTION
Minimal removal to limit future conflicts:
- UI form
- Post `after_create` callback
- Change defaults so they don't accidentally interfere