### PR TITLE
 [Artists] Re-add Artists (Directors)

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -73,7 +73,7 @@ class ArtistsController < ApplicationController
   def update
     ensure_can_edit(CurrentUser.user)
     @artist.update(artist_params)
-    flash[:notice] = @artist.valid? ? "Artist updated" : @artist.errors.full_messages.join("; ")
+    flash[:notice] = @artist.valid? ? "Director updated" : @artist.errors.full_messages.join("; ")
     respond_with(@artist)
   end
 
@@ -82,7 +82,7 @@ class ArtistsController < ApplicationController
     @artist.destroy
     respond_with(@artist) do |format|
       format.html do
-        redirect_to(artists_path, notice: @artist.valid? ? "Artist deleted" : @artist.errors.full_messages.join("; "))
+        redirect_to(artists_path, notice: @artist.valid? ? "Director deleted" : @artist.errors.full_messages.join("; "))
       end
     end
   end
@@ -124,7 +124,7 @@ class ArtistsController < ApplicationController
   end
 
   def ensure_can_edit(user)
-    raise(User::PrivilegeError, "Artist is locked.") unless @artist.editable_by?(user)
+    raise(User::PrivilegeError, "Director is locked.") unless @artist.editable_by?(user)
   end
 
   def artist_params

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -106,7 +106,7 @@ class StaticController < ApplicationController
         { key: :tools, title: "Tools" },
       ],
       [
-        # { key: :artists, title: "Artists" },
+        { key: :artists, title: "Artists" },
         { key: :tags, title: "Tags" },
         { key: :notes, title: "Notes" },
         { key: :pools, title: "Pools" },
@@ -161,11 +161,11 @@ class StaticController < ApplicationController
     add_link[:tools, "Privacy Policy", privacy_policy_path]
     add_link[:tools, "Code of Conduct", code_of_conduct_path]
 
-    # add_link[:artists, "Listing", artists_path]
-    # add_link[:artists, "URLs", artist_urls_path]
+    add_link[:artists, "Listing", artists_path]
+    add_link[:artists, "URLs", artist_urls_path]
     # add_link[:artists, "Avoid Posting Entries", avoid_postings_path]
     # add_link[:artists, "Avoid Posting List", avoid_posting_static_path]
-    # add_link[:artists, "Changes", artist_versions_path]
+    add_link[:artists, "Changes", artist_versions_path]
 
     add_link[:tags, "Listing", tags_path]
     add_link[:tags, "Type Changes", tag_type_versions_path]
@@ -246,7 +246,7 @@ class StaticController < ApplicationController
     add_link[:users, "Staff Notes", staff_notes_path] if CurrentUser.can_view_staff_notes?
 
     add_link[:posts, "Help", help_page_path(id: "posts")]
-    # add_link[:artists, "Help", help_page_path(id: "artists")]
+    add_link[:artists, "Help", help_page_path(id: "artists")]
     add_link[:tags, "Help", help_page_path(id: "tags")]
     add_link[:notes, "Help", help_page_path(id: "notes")]
     add_link[:pools, "Help", help_page_path(id: "pools")]

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -106,7 +106,7 @@ class StaticController < ApplicationController
         { key: :tools, title: "Tools" },
       ],
       [
-        { key: :artists, title: "Artists" },
+        { key: :artists, title: "Directors" },
         { key: :tags, title: "Tags" },
         { key: :notes, title: "Notes" },
         { key: :pools, title: "Pools" },
@@ -246,7 +246,7 @@ class StaticController < ApplicationController
     add_link[:users, "Staff Notes", staff_notes_path] if CurrentUser.can_view_staff_notes?
 
     add_link[:posts, "Help", help_page_path(id: "posts")]
-    add_link[:artists, "Help", help_page_path(id: "artists")]
+    add_link[:artists, "Help", help_page_path(id: "directors")]
     add_link[:tags, "Help", help_page_path(id: "tags")]
     add_link[:notes, "Help", help_page_path(id: "notes")]
     add_link[:pools, "Help", help_page_path(id: "pools")]

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -89,17 +89,17 @@ class ModActionDecorator < ApplicationDecorator
 
       ### Artist ###
     when "artist_delete"
-      "Deleted artist ##{vals['artist_id']} (#{vals['artist_name']})"
+      "Deleted director ##{vals['artist_id']} (#{vals['artist_name']})"
     when "artist_page_rename"
-      "Renamed artist page (\"#{vals['old_name']}\":/artists/show_or_new?name=#{vals['old_name']} → \"#{vals['new_name']}\":/artists/show_or_new?name=#{vals['new_name']})"
+      "Renamed director page (\"#{vals['old_name']}\":/directors/show_or_new?name=#{vals['old_name']} → \"#{vals['new_name']}\":/directors/show_or_new?name=#{vals['new_name']})"
     when "artist_page_lock"
-      "Locked artist page artist ##{vals['artist_page']}"
+      "Locked director page director ##{vals['artist_page']}"
     when "artist_page_unlock"
-      "Unlocked artist page artist ##{vals['artist_page']}"
+      "Unlocked director page director ##{vals['artist_page']}"
     when "artist_user_linked"
-      "Linked #{user} to artist ##{vals['artist_page']}"
+      "Linked #{user} to director ##{vals['artist_page']}"
     when "artist_user_unlinked"
-      "Unlinked #{user} from artist ##{vals['artist_page']}"
+      "Unlinked #{user} from director ##{vals['artist_page']}"
 
       ### Avoid Posting ###
     when "avoid_posting_create"

--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -9,7 +9,7 @@ module ArtistsHelper
     else
       link = link_to(name, new_artist_path(artist: { name: name }))
       return link.html_safe if hide_new_notice
-      notice = tag.span("*", class: "new-artist", title: "No artist with this name currently exists.")
+      notice = tag.span("*", class: "new-artist", title: "No director with this name currently exists.")
       "#{link} #{notice}".html_safe
     end
   end

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -635,10 +635,10 @@
           newButton.classList.add("toggle-button");
           newButton.innerHTML = artistName;
           newButton.onclick = () => {
-            let val = (this.tagEntries.artist ?? "").trim().split(" ").filter(n => n);
+            let val = (this.tagEntries.director ?? "").trim().split(" ").filter(n => n);
             if (val.includes(artistName)) val = val.filter(n => n !== artistName);
             else val.push(artistName);
-            this.tagEntries.artist = val.join(" ") + " ";
+            this.tagEntries.director = val.join(" ") + " ";
           };
           buttonRow.appendChild(newButton);
         }

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -627,7 +627,7 @@
         buttonRow.classList.add("upload-artist-tags");
 
         const hint = document.createElement("div");
-        hint.innerHTML = "Linked artist tags:";
+        hint.innerHTML = "Linked director tags:";
         buttonRow.appendChild(hint);
 
         for (const artistName of window.uploaderSettings.verifiedArtistTags) {

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -11,7 +11,7 @@ class DbExportJob < ApplicationJob
   end
 
   EXPORTS = {
-    "artists" => {
+    "directors" => {
       query: read_export_sql("artists"),
     },
     "bulk_update_requests" => {

--- a/app/jobs/sitemap_generator_job.rb
+++ b/app/jobs/sitemap_generator_job.rb
@@ -78,7 +78,7 @@ class SitemapGeneratorJob < ApplicationJob
         # Generate media sitemaps for the included posts.
         included_posts.each do |post|
           post.inject_tag_categories(types)
-          artist_names = post.artist_tags.map(&:name).join(", ").presence || "unknown artist"
+          artist_names = post.artist_tags.map(&:name).join(", ").presence || "unknown director"
 
           if post.is_video?
             add "/posts/#{post.id}", lastmod: post.updated_at, videos: [{

--- a/app/logical/bulk_update_request_importer.rb
+++ b/app/logical/bulk_update_request_importer.rb
@@ -190,6 +190,7 @@ class BulkUpdateRequestImporter
       end
     end
 
+    tag_alias.rename_artist
     raise Error, "Error: Alias would modify other aliases or implications through transitive relationships. (create alias #{tag_alias.antecedent_name} -> #{tag_alias.consequent_name})" if tag_alias.has_transitives
     tag_alias.approve!(approver: approver, update_topic: false)
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -382,7 +382,7 @@ class Artist < ApplicationRecord
 
     def categorize_tag
       if new_record? || saved_change_to_name?
-        Tag.find_or_create_by_name("artist:#{name}")
+        Tag.find_or_create_by_name("director:#{name}")
       end
     end
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -311,7 +311,7 @@ class Artist < ApplicationRecord
 
     def revert_to!(version)
       if id != version.artist_id
-        raise RevertError.new("You cannot revert to a previous version of another artist.")
+        raise RevertError.new("You cannot revert to a previous version of another director.")
       end
 
       self.name = version.name
@@ -402,7 +402,7 @@ class Artist < ApplicationRecord
       return if CurrentUser.is_staff?
 
       if is_locked?
-        errors.add(:base, "Artist is locked")
+        errors.add(:base, "Director is locked")
         throw :abort
       end
     end
@@ -510,9 +510,9 @@ class Artist < ApplicationRecord
 
   module AvoidPostingMethods
     def validate_protected_properties_not_changed
-      errors.add(:name, "cannot be changed while the artist is on the avoid posting list") if will_save_change_to_name?
-      errors.add(:group_name, "cannot be changed while the artist is on the avoid posting list") if will_save_change_to_group_name?
-      errors.add(:other_names, "cannot be changed while the artist is on the avoid posting list") if will_save_change_to_other_names?
+      errors.add(:name, "cannot be changed while the director is on the avoid posting list") if will_save_change_to_name?
+      errors.add(:group_name, "cannot be changed while the director is on the avoid posting list") if will_save_change_to_group_name?
+      errors.add(:other_names, "cannot be changed while the director is on the avoid posting list") if will_save_change_to_other_names?
       throw(:abort) if errors.any?
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,6 +27,7 @@ class Post < ApplicationRecord
   validates :description, length: { maximum: Danbooru.config.post_descr_max_size }, if: :description_changed?
   validate :added_tags_are_valid, if: :should_process_tags?
   validate :removed_tags_are_valid, if: :should_process_tags?
+  validate :has_artist_tag, if: :should_process_tags?
   validate :has_enough_tags, if: :should_process_tags?
   validate :post_is_not_its_own_parent
   validate :updater_can_change_rating
@@ -1179,14 +1180,20 @@ class Post < ApplicationRecord
     # Fetches the data for the artist tags to find any that have the linked artists matching the uploader
     # Sends a db request to look up the artist data.
     def uploader_linked_artists
-      []
+      @uploader_linked_artists ||= begin
+        tags = artist_tags.filter_map(&:artist).select { |artist| artist.linked_user_id == uploader_id }
+        tags.map(&:name)
+      end
     end
 
     ## DB!
     # Fetches ALL linked users for the post's artist tags and returns the user IDs.
     # Sends a db request to look up the artist data.
     def linked_users
-      []
+      @linked_users ||= begin
+        tags = artist_tags.filter_map(&:artist).select(&:linked_user_id?)
+        tags.map(&:linked_user_id)
+      end
     end
 
     ## DB!
@@ -2075,6 +2082,7 @@ class Post < ApplicationRecord
       added_invalid_tags = added.select { |t| t.category == Tag.categories.invalid }
       new_tags = added.select { |t| t.post_count <= 0 }
       new_general_tags = new_tags.select { |t| t.category == Tag.categories.general }
+      new_artist_tags = new_tags.select { |t| t.category == Tag.categories.director }
       # See https://github.com/e621ng/e621ng/issues/494
       # If the tag is fresh it's save to assume it was created with a prefix
       repopulated_tags = new_tags.select { |t| t.category != Tag.categories.general && t.category != Tag.categories.meta && t.created_at < 10.seconds.ago }
@@ -2095,6 +2103,12 @@ class Post < ApplicationRecord
         n = repopulated_tags.size
         tag_wiki_links = repopulated_tags.map { |tag| "[[#{tag.name}]]" }
         warnings.add(:base, "Repopulated #{n} old #{'tag'.pluralize(n)}: #{tag_wiki_links.join(', ')}")
+      end
+
+      new_artist_tags.each do |tag|
+        if tag.artist.blank?
+          warnings.add(:base, "Artist [[#{tag.name}]] requires an artist entry. \"Create new artist entry\":[/artists/new?artist%5Bname%5D=#{CGI.escape(tag.name)}]")
+        end
       end
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2107,7 +2107,7 @@ class Post < ApplicationRecord
 
       new_artist_tags.each do |tag|
         if tag.artist.blank?
-          warnings.add(:base, "Artist [[#{tag.name}]] requires an artist entry. \"Create new artist entry\":[/artists/new?artist%5Bname%5D=#{CGI.escape(tag.name)}]")
+          warnings.add(:base, "Director [[#{tag.name}]] requires an director entry. \"Create new director entry\":[/artists/new?artist%5Bname%5D=#{CGI.escape(tag.name)}]")
         end
       end
     end

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -285,6 +285,7 @@ class TagAlias < TagRelationship
         update_posts_locked_tags
         update_blacklists
         update_posts
+        rename_artist
         forum_updater.update(approval_message(approver), "APPROVED") if update_topic
         update(status: "active", post_count: consequent_tag&.post_count || 0)
         TagAliasFinalizeJob.perform_later(id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -832,10 +832,10 @@ class User < ApplicationRecord
     # extra attributes returned for /users/:id.json but not for /users.json.
     def full_attributes
       %i[
-        wiki_page_version_count pool_version_count
+        wiki_page_version_count artist_version_count pool_version_count
         forum_post_count comment_count flag_count favorite_count
         positive_feedback_count neutral_feedback_count negative_feedback_count
-        upload_limit profile_about
+        upload_limit profile_about profile_artinfo
       ]
     end
   end

--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -79,7 +79,7 @@ class TagSetPresenter < Presenter
 
   def tag_link(tag, link_text = tag.name, link_type = :tag)
     link = link_type == :wiki_page ? show_or_new_wiki_pages_path(title: tag.name) : posts_path(tags: tag.name)
-    itemprop = ""
+    itemprop = 'itemprop="author"' if tag.category == Tag.categories.director
     %(<a rel="nofollow" class="search-tag" #{itemprop} href="#{link}">#{h(link_text)}</a> )
   end
 end

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -1,7 +1,7 @@
 <div id="c-artist-urls">
   <div id="a-index">
     <%= form_search(path: artist_urls_path) do |f| %>
-      <%= f.input :artist_name, label: "Artist Name", autocomplete: "artist" %>
+      <%= f.input :artist_name, label: "Director Name", autocomplete: "artist" %>
       <%= f.input :url_matches, label: "URL" %>
       <%= f.input :normalized_url_matches, label: "Normalized URL" %>
       <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
@@ -12,7 +12,7 @@
       <thead>
         <tr>
           <th>ID</th>
-          <th>Artist Name</th>
+          <th>Director Name</th>
           <th>URL</th>
           <th>Normalized URL</th>
           <th>Active?</th>
@@ -42,5 +42,5 @@
 <%= render "artists/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist URLs
+  Director URLs
 <% end %>

--- a/app/views/artist_versions/index.html.erb
+++ b/app/views/artist_versions/index.html.erb
@@ -1,6 +1,6 @@
 <div id="c-artist-versions">
   <div id="a-index">
-    <h1>Artist History</h1>
+    <h1>Director History</h1>
 
     <%= render "search" %>
     <%= render "standard_listing" %>
@@ -11,5 +11,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist Versions
+  Director Versions
 <% end %>

--- a/app/views/artist_versions/search.html.erb
+++ b/app/views/artist_versions/search.html.erb
@@ -9,5 +9,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Artist Changes
+  Search Director Changes
 <% end %>

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -7,7 +7,7 @@
   <% else %>
     <p><%= @artist.name %></p>
     <% if @artist.dnp_restricted? %>
-      <p>Name, other names, and group name cannot be edited for artists on the <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</p>
+      <p>Name, other names, and group name cannot be edited for directors on the <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</p>
     <% end %>
   <% end %>
   <% if CurrentUser.is_staff? %>
@@ -21,7 +21,7 @@
   <%= f.input :url_string, label: "URLs", as: :text, input_html: { size: "80x10", value: params.dig(:artist, :url_string) || @artist.urls.join("\n")}, hint: "You can prefix a URL with - to mark it as dead." %>
 
   <% if @artist.is_note_locked? %>
-    <p>Artist is note locked. Notes cannot be edited.</p>
+    <p>Director is note locked. Notes cannot be edited.</p>
   <% end %>
   <%= f.input :notes, as: :dtext, limit: Danbooru.config.wiki_page_max_size, disabled: @artist.is_note_locked?, allow_color: true %>
   <%= f.button :submit, "Submit" %>

--- a/app/views/artists/_quick_search.html.erb
+++ b/app/views/artists/_quick_search.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(artists_path, :method => :get) do %>
-  <%= text_field "search", "any_name_or_url_matches", id: "quick_search_name", placeholder: "Search artists", "data-autocomplete": "artist" %>
+  <%= text_field "search", "any_name_or_url_matches", id: "quick_search_name", placeholder: "Search directors", "data-autocomplete": "artist" %>
 <% end %>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <%= subnav_link_to "Recent changes", artist_versions_path %>
   <%= subnav_link_to "URLs", artist_urls_path %>
-  <%= subnav_link_to "Help", help_page_path(id: "artists") %>
+  <%= subnav_link_to "Help", help_page_path(id: "directors") %>
   <% if @artist && !@artist.new_record? %>
     <li class="divider"></li>
     <%= subnav_link_to "Posts (#{@artist.tag.try(:post_count).to_i})", posts_path(tags: @artist.name) %>
@@ -17,7 +17,7 @@
     <% end %>
     <%= subnav_link_to "History", artist_versions_path(search: { artist_id: @artist.id }), data: { hotkey: "history" } %>
     <% if @artist.deletable_by?(CurrentUser.user) %>
-      <%= subnav_link_to "Delete", artist_path(@artist), method: :delete, data: { confirm: "Are you sure you want to delete this artist? This cannot be undone." } %>
+      <%= subnav_link_to "Delete", artist_path(@artist), method: :delete, data: { confirm: "Are you sure you want to delete this director? This cannot be undone." } %>
     <% end %>
     <% if @artist.is_dnp? %>
       <li class="divider"></li>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:secondary_links) do %>
   <li><%= render "artists/quick_search" %></li>
   <%= subnav_link_to "Listing", artists_path %>
-  <%= subnav_link_to "Avoid Posting", avoid_posting_static_path %>
+  <%# <%= subnav_link_to "Avoid Posting", avoid_posting_static_path %>
   <% if CurrentUser.is_member? %>
     <%= subnav_link_to "New", new_artist_path %>
   <% end %>

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -1,7 +1,7 @@
 <div id="c-artists">
   <div id="a-show">
     <h1>
-      Artist: <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_id}" %>
+      Director: <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_id}" %>
       <% if @artist.is_locked? %>
         (locked)
       <% end %>
@@ -14,7 +14,7 @@
           <% if @artist.avoid_posting.pretty_details.present? %>
             <%= format_text(@artist.avoid_posting.pretty_details, inline: true) %>
           <% else %>
-            Do not upload artwork created by this artist.
+            Do not upload artwork created by this director.
           <% end %>
         </div>
         <% if CurrentUser.is_staff? && @artist.avoid_posting.staff_notes.present? %>
@@ -56,5 +56,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist - <%= @artist.name %>
+  Director - <%= @artist.name %>
 <% end %>

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -42,7 +42,7 @@
   <% if CurrentUser.user.is_staff? %>
     <li><strong>Other</strong></li>
     <ul>
-      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Date.current}" }) %></li>
+      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Director: #{artist.name} #{Date.current}" }) %></li>
     </ul>
   <% end %>
 </ul>

--- a/app/views/artists/edit.html.erb
+++ b/app/views/artists/edit.html.erb
@@ -1,12 +1,12 @@
 <div id="c-artists">
   <div id="a-edit">
-    <h1>Edit Artist</h1>
+    <h1>Edit Director</h1>
 
     <% if @artist.editable_by?(CurrentUser.user) %>
       <%= render "form" %>
 
     <% elsif @artist.is_locked? %>
-      <p>This artist entry is locked and cannot be edited.</p>
+      <p>This director entry is locked and cannot be edited.</p>
 
     <% end %>
   </div>
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Artist - <%= @artist.name %>
+  Edit Director - <%= @artist.name %>
 <% end %>

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -32,5 +32,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artists
+  Directors
 <% end %>

--- a/app/views/artists/new.html.erb
+++ b/app/views/artists/new.html.erb
@@ -1,6 +1,6 @@
 <div id="c-artists">
   <div id="a-new">
-    <h1>New Artist</h1>
+    <h1>New Director</h1>
 
     <%= error_messages_for :artist %>
 
@@ -11,5 +11,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Artist
+  New Director
 <% end %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -4,7 +4,7 @@
       <%= render "summary", artist: @artist %>
     </div>
   <% else %>
-    <p>The artist requested removal of this page.</p>
+    <p>The director requested removal of this page.</p>
   <% end %>
 <% end %>
 

--- a/app/views/artists/show_or_new.html.erb
+++ b/app/views/artists/show_or_new.html.erb
@@ -1,5 +1,5 @@
 <%= render layout: "show" do %>
   <div>
-    <p>This artist entry does not exist. <%= link_to "Create new artist entry", new_artist_path(artist: { name: params[:name] }) %>.</p>
+    <p>This director entry does not exist. <%= link_to "Create new director entry", new_artist_path(artist: { name: params[:name] }) %>.</p>
   </div>
 <% end %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -5,9 +5,9 @@
   <div class="author-info">
     <div class="name-rank">
       <h4 class="author-name">
-        <%= link_to_user comment.creator %> 
+        <%= link_to_user comment.creator %>
         <% if !post.nil? %>
-          <%= svg_icon(:chexagon, class: "chexagon", title: "Comment by an artist on this post") if post.linked_users.include?(comment.creator_id) %>
+          <%= svg_icon(:chexagon, class: "chexagon", title: "Comment by a director on this post") if post.linked_users.include?(comment.creator_id) %>
         <% end %>
       </h4>
       <%= user_level_plain(comment.creator) %>

--- a/app/views/layouts/navigation/_main_links.html.erb
+++ b/app/views/layouts/navigation/_main_links.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <%= decorated_nav_link_to("Profile", :user, user_path(CurrentUser.user), class: "nav-hidden") %>
 <% end %>
-<%= decorated_nav_link_to("Artists", :brush, artists_path) %>
+<%= decorated_nav_link_to("Directors", :brush, artists_path) %>
 <%= decorated_nav_link_to("Posts", :images, posts_path) %>
 <%= decorated_nav_link_to("Pools", :library, gallery_pools_path) %>
 <%= decorated_nav_link_to("Sets", :group, post_sets_path) %>

--- a/app/views/layouts/navigation/_main_links.html.erb
+++ b/app/views/layouts/navigation/_main_links.html.erb
@@ -3,6 +3,7 @@
 <% else %>
   <%= decorated_nav_link_to("Profile", :user, user_path(CurrentUser.user), class: "nav-hidden") %>
 <% end %>
+<%= decorated_nav_link_to("Artists", :brush, artists_path) %>
 <%= decorated_nav_link_to("Posts", :images, posts_path) %>
 <%= decorated_nav_link_to("Pools", :library, gallery_pools_path) %>
 <%= decorated_nav_link_to("Sets", :group, post_sets_path) %>

--- a/app/views/post_replacements/partials/show/_post_replacement.html.erb
+++ b/app/views/post_replacements/partials/show/_post_replacement.html.erb
@@ -39,7 +39,7 @@
   <td>
     <dt>Version Uploader</dt>
     <dd><%= link_to_user post_replacement.creator %><% if post_replacement.uploader_linked_artists.any? %>
-      <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to one of the artist tags") %><% end %>
+      <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to one of the director tags") %><% end %>
     </dd>
 
     <% unless post_replacement.is_backup? || post_replacement.is_pending? || post_replacement.uploader_on_approve.nil? %>
@@ -72,21 +72,21 @@
       <%= svg_icon(:circle_check_small, title: "This is the current version", height: 13.5, width: 13.5, class: "inline-icons") if post_replacement.is_current? %>
       <% if post_replacement.is_pending? %> Replacement: <% end %>
       <%= post_replacement.image_width %>x<%= post_replacement.image_height %> <%= post_replacement.file_ext %>
-      (<%= post_replacement.file_size.to_fs(:human_size, precision: 5) %><% if post_replacement.is_video? %>, 
-      <%= post_replacement.post.duration %>s<% end -%>) </dd> 
+      (<%= post_replacement.file_size.to_fs(:human_size, precision: 5) %><% if post_replacement.is_video? %>,
+      <%= post_replacement.post.duration %>s<% end -%>) </dd>
     <dd class="replacement-compact-row">
       <% if post_replacement.is_pending? %>
       Current:
         <%= post_replacement.post.image_width %>x<%= post_replacement.post.image_height %> <%= post_replacement.post.file_ext %>
-        (<%= post_replacement.post.file_size.to_fs(:human_size, precision: 5) %><% if post_replacement.post.is_video? %>, 
-        <%= post_replacement.post.duration %>s<% end -%>) 
+        (<%= post_replacement.post.file_size.to_fs(:human_size, precision: 5) %><% if post_replacement.post.is_video? %>,
+        <%= post_replacement.post.duration %>s<% end -%>)
       <% end %>
     </dd>
     <dt class="replacement-spaced-row">File Info</dt>
     <dd class="replacement-compact-row">File Name: <%= truncate post_replacement.file_name, length: 64 %></dd>
     <dd class="replacement-compact-row">ID: <%= truncate post_replacement.storage_id, length: 64 %></dd>
     <% if post_replacement.md5.present? %>
-      <dd class="replacement-compact-row">MD5: <%= post_replacement.md5 %></dd> 
+      <dd class="replacement-compact-row">MD5: <%= post_replacement.md5 %></dd>
     <% end %>
   </td>
   <td>

--- a/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
+++ b/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
@@ -24,7 +24,7 @@
     <span class="tag-list-name">
       <%= tag.name.tr("_", " ") %>
       <% if post.present? && post.uploader_linked_artists.include?(tag.name) %>
-        <%= svg_icon(:chexagon, class: "chexagon", title: "Uploaded by the artist") %>
+        <%= svg_icon(:chexagon, class: "chexagon", title: "Uploaded by the director") %>
       <% end %>
     </span>
 

--- a/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
+++ b/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
@@ -7,7 +7,7 @@
   <a
     class="tag-list-wiki"
     rel="nofollow"
-    href="<%= show_or_new_wiki_pages_path(title: tag.name) %>"
+    href="<%= tag.category == Tag.categories.director ? show_or_new_artists_path(name: tag.name) : show_or_new_wiki_pages_path(title: tag.name) %>"
   >?</a>
 
   <% if query.present? %>

--- a/app/views/posts/partials/show/content/notices/_avoid_posting.html.erb
+++ b/app/views/posts/partials/show/content/notices/_avoid_posting.html.erb
@@ -13,7 +13,7 @@
               <span class="artist">
               <%= link_to dnp.artist_name, avoid_posting_path(dnp) %>
                 <% if dnp.artist.try(:linked_user_id) == post.uploader_id %>
-                  <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to this artist.") %>
+                  <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to this director.") %>
                 <% end %>
               </span>
               <span class="separator">-</span>

--- a/app/views/posts/partials/show/sidebar/_information.html.erb
+++ b/app/views/posts/partials/show/sidebar/_information.html.erb
@@ -81,7 +81,7 @@
     <li>
       Uploader: <%= link_to_user(post.uploader) %> <%= render(UserFeedbackComponent.new(user: post.uploader, style: :inline)) if CurrentUser.is_staff? %>
       <% if post.uploader_linked_artists.any? %>
-        <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to one of the artist tags") %>
+        <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to one of the director tags") %>
       <% end %>
     </li>
   <% end %>

--- a/app/views/staff/moderator_dashboards/_activity_artist.html.erb
+++ b/app/views/staff/moderator_dashboards/_activity_artist.html.erb
@@ -1,5 +1,5 @@
 <table class="striped">
-  <caption>Artist Updates</caption>
+  <caption>Director Updates</caption>
   <thead>
     <tr>
       <th>User</th>

--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <%= f.input :profile_about, as: :dtext, label: "About", limit: Danbooru.config.user_about_max_size, allow_color: true %>
-      <%= f.input :profile_artinfo, as: :dtext, label: "Commission Info", limit: Danbooru.config.user_about_max_size, allow_color: true %>
+      <%= f.input :profile_artinfo, as: :dtext, label: "Director Info", limit: Danbooru.config.user_about_max_size, allow_color: true %>
       <%= f.input :custom_title, input_html: { size: 50 }, hint: "Replaces the level badge text. Leave blank to show level." %>
       <%= f.input :base_upload_limit %>
 

--- a/app/views/static/robots.erb
+++ b/app/views/static/robots.erb
@@ -89,6 +89,7 @@ Disallow: /post_votes
 
 # Version history
 Disallow: /artist_versions
+Disallow: /director_versions
 Disallow: /note_versions
 Disallow: /pool_versions
 Disallow: /post_versions
@@ -97,6 +98,7 @@ Disallow: /wiki_page_versions
 
 # Internal / API-only endpoints
 Disallow: /artist_urls
+Disallow: /director_urls
 Disallow: /avoid_postings
 Disallow: /avoid_posting_versions
 Disallow: /data/
@@ -127,6 +129,7 @@ Disallow: /posts/show_seq
 
 # Collection action pages
 Disallow: /artists/show_or_new
+Disallow: /directors/show_or_new
 Disallow: /wiki_pages/search
 Disallow: /wiki_pages/show_or_new
 
@@ -141,6 +144,7 @@ Disallow: /users
 
 # Parameterized searches - unbounded URL space
 Disallow: /artists?
+Disallow: /directors?
 Disallow: /pools?
 Disallow: /posts?
 Disallow: /tags?

--- a/app/views/tag_aliases/show.html.erb
+++ b/app/views/tag_aliases/show.html.erb
@@ -33,8 +33,8 @@
       <% if @tag_alias.consequent_tag&.artist&.is_dnp? || @tag_alias.antecedent_tag&.artist&.is_dnp? %>
         <li>
           <br />
-          <strong>Note:</strong> This tag alias is associated with a DNP artist.<br />
-          Please check the <%= link_to "artist page", artist_path(@tag_alias.consequent_tag&.artist || @tag_alias.antecedent_tag&.artist) %> for more information.
+          <strong>Note:</strong> This tag alias is associated with a DNP director.<br />
+          Please check the <%= link_to "director page", artist_path(@tag_alias.consequent_tag&.artist || @tag_alias.antecedent_tag&.artist) %> for more information.
         </li>
       <% end %>
 
@@ -44,9 +44,9 @@
           <strong>Linked User</strong>: <%= link_to_user @tag_alias.antecedent_tag.artist.linked_user %>
           <br />
           <% if @tag_alias.consequent_tag&.artist.blank? %>
-            <strong>Note:</strong> Antecedent artist page will be renamed to match the consequent tag upon approval.
+            <strong>Note:</strong> Antecedent director page will be renamed to match the consequent tag upon approval.
           <% elsif @tag_alias.consequent_tag&.artist&.linked_user_id.present? %>
-            <strong>Note:</strong> Consequent artist tag also has a linked user: <%= link_to_user @tag_alias.consequent_tag.artist.linked_user %>
+            <strong>Note:</strong> Consequent director tag also has a linked user: <%= link_to_user @tag_alias.consequent_tag.artist.linked_user %>
           <% else %>
             <strong>Note:</strong> Linked user will be transferred to the consequent tag upon approval.
           <% end %>

--- a/app/views/tag_implications/show.html.erb
+++ b/app/views/tag_implications/show.html.erb
@@ -21,8 +21,8 @@
       <% if @tag_implication.consequent_tag&.artist&.is_dnp? || @tag_implication.antecedent_tag&.artist&.is_dnp? %>
         <li>
           <br />
-          <strong>Note:</strong> This tag alias is associated with a DNP artist.<br />
-          Please check the <%= link_to "artist page", artist_path(@tag_implication.consequent_tag&.artist || @tag_implication.antecedent_tag&.artist) %> for more information.
+          <strong>Note:</strong> This tag alias is associated with a DNP director.<br />
+          Please check the <%= link_to "director page", artist_path(@tag_implication.consequent_tag&.artist || @tag_implication.antecedent_tag&.artist) %> for more information.
         </li>
       <% end %>
     </ul>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -3,7 +3,6 @@
   <%= f.input :category, label: "Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
   <%= f.input :order, collection: [%w[Count count], %w[Name name], %w[Newest date]], include_blank: false %>
   <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: "Any" %>
-  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true %>
   <%= f.input :has_artist, label: "Has director?", collection: %w[yes no], include_blank: true %>
   <%= f.input :hide_empty, label: "Hide empty?", as: :boolean, default: true %>
 <% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -3,5 +3,7 @@
   <%= f.input :category, label: "Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
   <%= f.input :order, collection: [%w[Count count], %w[Name name], %w[Newest date]], include_blank: false %>
   <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: "Any" %>
+  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true %>
+  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: true %>
   <%= f.input :hide_empty, label: "Hide empty?", as: :boolean, default: true %>
 <% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -4,6 +4,6 @@
   <%= f.input :order, collection: [%w[Count count], %w[Name name], %w[Newest date]], include_blank: false %>
   <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: "Any" %>
   <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true %>
-  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: true %>
+  <%= f.input :has_artist, label: "Has director?", collection: %w[yes no], include_blank: true %>
   <%= f.input :hide_empty, label: "Hide empty?", as: :boolean, default: true %>
 <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -14,7 +14,11 @@
           <tr>
             <td><%= tag.post_count %></td>
             <td class="category-<%= tag.category %>">
-              <%= link_to_wiki_or_new("?", tag.name) %>
+              <% if tag.category == Tag.categories.director %>
+                <%= link_to("?",  show_or_new_artists_path(:name => tag.name)) %>
+              <% else %>
+                <%= link_to_wiki_or_new("?", tag.name) %>
+              <% end %>
               <%= link_to(tag.name, posts_path(:tags => tag.name)) %>
             </td>
             <td>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -89,8 +89,8 @@
   </tab-body>
 </tab-entry>
 
-<tab-entry tab="<%= tab_name %>" group="profile" class="bigtext" search="user profile commission info">
-  <tab-head><%= form.label :profile_artinfo, "Commission Info" %></tab-head>
+<tab-entry tab="<%= tab_name %>" group="profile" class="bigtext" search="user profile director info">
+  <tab-head><%= form.label :profile_artinfo, "Director Info" %></tab-head>
   <tab-body>
     <%= form.input_field :profile_artinfo,
       as: :dtext,

--- a/app/views/users/partials/show/_about.html.erb
+++ b/app/views/users/partials/show/_about.html.erb
@@ -10,7 +10,7 @@
 
 <% if has_artinfo %>
   <tab-entry tab="artinfo" class="profile-readmore profile-artinfo-section flex">
-    <tab-head>Commission Information</tab-head>
+    <tab-head>Artist Information</tab-head>
     <tab-body class="content dtext-container">
       <%= format_text(user.profile_artinfo, allow_color: true) %>
       <button class="content-readmore">Show More</button>

--- a/app/views/users/partials/show/_about.html.erb
+++ b/app/views/users/partials/show/_about.html.erb
@@ -10,7 +10,7 @@
 
 <% if has_artinfo %>
   <tab-entry tab="artinfo" class="profile-readmore profile-artinfo-section flex">
-    <tab-head>Artist Information</tab-head>
+    <tab-head>Director Information</tab-head>
     <tab-body class="content dtext-container">
       <%= format_text(user.profile_artinfo, allow_color: true) %>
       <button class="content-readmore">Show More</button>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -70,7 +70,7 @@
       <% if user.artist_version_count != 0 %>
         <a href="<%= artist_versions_path(search: { updater_id: user.id }) %>" class="entry">
           <h5><%= user.artist_version_count %></h5>
-          <span>Artist</span>
+          <span>Director</span>
         </a>
       <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
         <button role="tab" name="about">About</button>
       <% end %>
       <% if has_artinfo %>
-        <button role="tab" name="artinfo">Commission Info</button>
+        <button role="tab" name="artinfo">Director Info</button>
       <% end %>
       <button role="tab" name="stats">Stats</button>
     </tabs-menu>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -36,7 +36,7 @@
         <% end %>
 
         <% if wiki_content.artist %>
-          <p><%= link_to "View artist", show_or_new_artists_path(name: wiki_content.artist.name) %></p>
+          <p><%= link_to "View director", show_or_new_artists_path(name: wiki_content.artist.name) %></p>
         <% end %>
 
         <%= wiki_page_alias_and_implication_list(wiki_content) %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -30,9 +30,13 @@
 
       <div id="wiki-page-body" class="dtext-container">
         <% if wiki_content.body.present? %>
-          <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  
+          <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>
         <% else %>
           <p>This wiki page is empty. <%= link_to "Click here to add details", edit_wiki_page_path(@wiki_page) %>.</p>
+        <% end %>
+
+        <% if wiki_content.artist %>
+          <p><%= link_to "View artist", show_or_new_artists_path(name: wiki_content.artist.name) %></p>
         <% end %>
 
         <%= wiki_page_alias_and_implication_list(wiki_content) %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -19,6 +19,10 @@
         <p>This wiki page is empty. <%= link_to "Click here to add details", new_wiki_page_path(wiki_page: { title: params[:title] }) %>.</p>
       </div>
 
+      <% if @wiki_page.tag&.category == Tag.categories.director %>
+        <%= link_to("View artist",  show_or_new_artists_path(name: @wiki_page.title)) %>
+      <% end %>
+
       <%= wiki_page_alias_and_implication_list(@wiki_page)%>
 
       <%= render "recent_posts" %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -20,7 +20,7 @@
       </div>
 
       <% if @wiki_page.tag&.category == Tag.categories.director %>
-        <%= link_to("View artist",  show_or_new_artists_path(name: @wiki_page.title)) %>
+        <%= link_to("View director",  show_or_new_artists_path(name: @wiki_page.title)) %>
       <% end %>
 
       <%= wiki_page_alias_and_implication_list(@wiki_page)%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,20 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :artists, constraints: id_name_constraint do
+    member do
+      put :revert
+    end
+    collection do
+      get :show_or_new
+    end
+  end
+  resources :artist_urls, only: %i[index]
+  resources :artist_versions, only: %i[index] do
+    collection do
+      get :search
+    end
+  end
   resources :bans
   resources :bulk_update_requests do
     member do
@@ -485,7 +499,14 @@ Rails.application.routes.draw do
   resources :ftopics, controller: "forum_topics"
   resources :fposts, controller: "forum_posts"
 
-  # legacy aliases
+  # Legacy aliases
+  get "/artist" => redirect { |_params, req| "/artists?page=#{req.params[:page]}&search[name]=#{CGI.escape(req.params[:name].to_s)}" }
+  get "/artist/index" => redirect { |_params, req| "/artists?page=#{req.params[:page]}" }
+  get "/artist/show/:id" => redirect("/artists/%{id}")
+  get "/artist/show" => redirect { |_params, req| "/artists?name=#{CGI.escape(req.params[:name].to_s)}" }
+  get "/artist/history/:id" => redirect("/artist_versions?search[artist_id]=%{id}")
+  get "/artist/recent_changes" => redirect("/artist_versions")
+
   get "/comment" => redirect { |_params, req| "/comments?page=#{req.params[:page]}" }
   get "/comment/index" => redirect { |_params, req| "/comments?page=#{req.params[:page]}" }
   get "/comment/show/:id" => redirect("/comments/%{id}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ Rails.application.routes.draw do
     end
   end
 
-  artists_resources = proc do
+  resources :artists, path: "directors", constraints: id_name_constraint do
     member do
       put :revert
     end
@@ -203,17 +203,12 @@ Rails.application.routes.draw do
       get :show_or_new
     end
   end
-  artist_versions_resources = proc do
+  resources :artist_urls, path: "director_urls", only: %i[index]
+  resources :artist_versions, path: "director_versions", only: %i[index] do
     collection do
       get :search
     end
   end
-  resources :artists, path: "directors", as: :directors, constraints: id_name_constraint, &artists_resources
-  resources :artists, &artists_resources
-  resources :artist_urls, path: "director_urls", as: :director_urls, only: %i[index]
-  resources :artist_urls
-  resources :artist_versions, path: "director_versions", as: :director_versions, only: %i[index], &artist_versions_resources
-  resources :artist_versions, &artist_versions_resources
   resources :bans
   resources :bulk_update_requests do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :artists, constraints: id_name_constraint do
+  artists_resources = proc do
     member do
       put :revert
     end
@@ -203,12 +203,17 @@ Rails.application.routes.draw do
       get :show_or_new
     end
   end
-  resources :artist_urls, only: %i[index]
-  resources :artist_versions, only: %i[index] do
+  artist_versions_resources = proc do
     collection do
       get :search
     end
   end
+  resources :artists, path: "directors", as: :directors, constraints: id_name_constraint, &artists_resources
+  resources :artists, &artists_resources
+  resources :artist_urls, path: "director_urls", as: :director_urls, only: %i[index]
+  resources :artist_urls
+  resources :artist_versions, path: "director_versions", as: :director_versions, only: %i[index], &artist_versions_resources
+  resources :artist_versions, &artist_versions_resources
   resources :bans
   resources :bulk_update_requests do
     member do
@@ -341,6 +346,7 @@ Rails.application.routes.draw do
       get :comments, to: "comments#for_post"
       resource :similar, only: [], controller: "post_recommendations" do
         get :artist
+        get :director, action: :artist
         get :tags
         get "", to: redirect { |params, req| "/iqdb_queries#{req.format.json? ? '.json' : ''}?post_id=#{params[:id]}" }
       end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6415,3 +6415,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20100205162521'),
 ('20100204214746'),
 ('20100204211522');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6415,4 +6415,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20100205162521'),
 ('20100204214746'),
 ('20100204211522');
-

--- a/spec/decorators/mod_action_decorator_spec.rb
+++ b/spec/decorators/mod_action_decorator_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ModActionDecorator do
     context "with artist actions" do
       it "artist_delete includes artist id and name" do
         desc = decorate("artist_delete", { "artist_id" => 3, "artist_name" => "someartist" }).format_description
-        expect(desc).to eq("Deleted artist #3 (someartist)")
+        expect(desc).to eq("Deleted director #3 (someartist)")
       end
 
       it "artist_page_rename includes old and new names" do

--- a/spec/indexes/post_index_spec.rb
+++ b/spec/indexes/post_index_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe PostIndex do
           expect(unverified_post.as_indexed_json[:artverified]).to be false
         end
 
-        it "returns true when the uploader is the linked artist for one of the post's artist tags", skip: "This fork does not use linked artists" do
+        it "returns true when the uploader is the linked artist for one of the post's artist tags" do
           expect(verified_post.as_indexed_json[:artverified]).to be true
         end
       end

--- a/spec/jobs/db_export_job_spec.rb
+++ b/spec/jobs/db_export_job_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe DbExportJob do
 
       it "exports artists" do
         create(:artist, name: "test_export_artist")
-        expect(export_csv("artists")).to include("test_export_artist")
+        expect(export_csv("directors")).to include("test_export_artist")
       end
 
       it "exports post versions for visible changes" do

--- a/spec/models/artist/lock_methods_spec.rb
+++ b/spec/models/artist/lock_methods_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Artist do
       CurrentUser.user = create(:user)
       artist.group_name = "any_group"
       expect(artist).not_to be_valid
-      expect(artist.errors[:base]).to include("Artist is locked")
+      expect(artist.errors[:base]).to include("Director is locked")
     end
 
     it "allows a member to edit an unlocked artist" do

--- a/spec/models/artist/tag_methods_spec.rb
+++ b/spec/models/artist/tag_methods_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Artist do
       expect { make_artist(name: name) }.to change(Tag, :count).by_at_least(1)
       tag = Tag.find_by(name: name)
       expect(tag).to be_present
-      expect(tag.category).to eq(Tag.categories.artist)
+      expect(tag.category).to eq(Tag.categories.director)
     end
 
     it "does not create a duplicate tag when one already exists" do
@@ -49,7 +49,7 @@ RSpec.describe Artist do
       artist = make_artist
       # categorize_tag has already fired; reload association
       artist.reload
-      expect(artist.category_id).to eq(Tag.categories.artist)
+      expect(artist.category_id).to eq(Tag.categories.director)
     end
   end
 end

--- a/spec/models/artist/validations_spec.rb
+++ b/spec/models/artist/validations_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Artist do
         CurrentUser.user = create(:user)
         artist.group_name = "some_group"
         expect(artist).not_to be_valid
-        expect(artist.errors[:base]).to include("Artist is locked")
+        expect(artist.errors[:base]).to include("Director is locked")
       end
     end
 

--- a/spec/models/avoid_posting/permissions_spec.rb
+++ b/spec/models/avoid_posting/permissions_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AvoidPosting do
       CurrentUser.user = create(:user)
       artist.name = "#{artist.name}_changed"
       expect(artist).not_to be_valid
-      expect(artist.errors[:name]).to include("cannot be changed while the artist is on the avoid posting list")
+      expect(artist.errors[:name]).to include("cannot be changed while the director is on the avoid posting list")
     end
 
     it "allows a bd_staff user to change the artist's name even with an active DNP" do

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Post do
           # Build a post with no artist-category tags
           post = build(:post, tag_string: "tag1 tag2 tag3 tag4 tag5 tag6 tag7 tag8 tag9 tag10")
           post.valid?
-          expect(post.warnings[:base].join).to match(/Artist tag is required/)
+          expect(post.warnings[:base].join).to match(/Director tag is required/)
         end
 
         it "does not add the artist warning on existing posts" do

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Post do
     end
 
     describe "warning validators" do
-      describe "has_artist_tag warning", skip: "This fork does not enforce artist tags" do
+      describe "has_artist_tag warning" do
         it "adds a warning on new posts without an artist tag" do
           # Build a post with no artist-category tags
           post = build(:post, tag_string: "tag1 tag2 tag3 tag4 tag5 tag6 tag7 tag8 tag9 tag10")

--- a/spec/models/post_flag/permissions_spec.rb
+++ b/spec/models/post_flag/permissions_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe PostFlag do
         expect(resolved_flag.can_appeal?(create(:user))).to be(false)
       end
 
-      it "returns true for linked users", skip: "Artist linking not implemented in this fork" do
+      it "returns true for linked users" do
         user = create(:user)
         artist = create(:artist, name: "linked_artist", linked_user_id: user.id)
         post.tag_string += " #{artist.name}"

--- a/spec/models/post_replacement/linked_artists_spec.rb
+++ b/spec/models/post_replacement/linked_artists_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PostReplacement do
-  describe "Uploader linked artists:", skip: "This fork does not use linked artists" do
+  describe "Uploader linked artists:" do
     let(:user) { create(:user, created_at: 2.weeks.ago) }
     let(:mod_user) { create(:moderator_user, created_at: 2.weeks.ago) }
 

--- a/spec/requests/artists_controller_spec.rb
+++ b/spec/requests/artists_controller_spec.rb
@@ -231,6 +231,7 @@ RSpec.describe ArtistsController do
     let(:avoid_posting) { CurrentUser.scoped(bd_user) { create(:avoid_posting, artist: artist) } }
 
     before do
+      skip "This fork doesn't support DNP"
       avoid_posting
     end
 


### PR DESCRIPTION
- Re-add the Artists feature, renaming it as "Directors" where visible.
- `/artists` and related routes are renamed to `/directors` but legacy `/artist` were added to reduce divergence
- `SITES_PRIORITY_ORDER` and `SITE_BLACKLIST` should be revised, the [e6ai.net upload whitelist](https://e6ai.net/upload_whitelists) might come in handy for this. I've left this out for now.
- The "Directors" icon is still a paintbrush, maybe there's something else we could use? I personally don't think it's an issue.