### PR TITLE
[Posts] Remove e621-specific safe mode text

### DIFF
--- a/app/views/favorites/_posts.html.erb
+++ b/app/views/favorites/_posts.html.erb
@@ -10,7 +10,7 @@
   <% if @post_set.hidden_posts.present? %>
     <div class="info hidden-posts-notice">
       <% if @post_set.safe_posts.present? %>
-        <%= @post_set.safe_posts.size %> post(s) on this page were hidden by safe mode (<%= Danbooru.config.app_name %>). Go to <%= link_to "e621", "https://e621.net/" %> or disable safe mode to view (<%= link_to "learn more", help_page_path(id: "user_settings") %>).<br>
+        <%= @post_set.safe_posts.size %> post(s) on this page were hidden by safe mode. Disable safe mode to view (<%= link_to "learn more", help_page_path(id: "user_settings") %>).<br>
       <% end %>
       <% if @post_set.login_blocked_posts.present? %>
         <%= @post_set.login_blocked_posts.size %> post(s) on this page were hidden because you need to be logged in to view them. <%= link_to "(learn more)", help_page_path(id: "global_blacklist") %>

--- a/app/views/posts/partials/index/_posts.html.erb
+++ b/app/views/posts/partials/index/_posts.html.erb
@@ -23,7 +23,7 @@
   <% if post_set.hidden_posts.present? %>
     <div class="info hidden-posts-notice">
       <% if post_set.safe_posts.present? %>
-        <%= post_set.safe_posts.size %> post(s) on this page were hidden by safe mode (<%= Danbooru.config.app_name %>). Go to <%= link_to "e621", "https://e621.net/" %> or disable safe mode to view (<%= link_to "learn more", help_page_path(id: "user_settings") %>).<br>
+        <%= post_set.safe_posts.size %> post(s) on this page were hidden by safe mode. Disable safe mode to view (<%= link_to "learn more", help_page_path(id: "user_settings") %>).<br>
       <% end %>
       <% if post_set.login_blocked_posts.present? %>
         <%= post_set.login_blocked_posts.size %> post(s) on this page were hidden because you need to be logged in to view them. <%= link_to "(learn more)", help_page_path(id: 'global_blacklist') %>


### PR DESCRIPTION
<img width="1290" height="62" alt="image" src="https://github.com/user-attachments/assets/e3a8bff9-1458-4d8c-9408-58b6807a9e3c" />
Fixes this.