### PR TITLE
WIP [Misc] Introduce TermHelper to handle fork terminology differences

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -73,7 +73,7 @@ class ArtistsController < ApplicationController
   def update
     ensure_can_edit(CurrentUser.user)
     @artist.update(artist_params)
-    flash[:notice] = @artist.valid? ? "Director updated" : @artist.errors.full_messages.join("; ")
+    flash[:notice] = @artist.valid? ? tm("{{Artist}} updated") : @artist.errors.full_messages.join("; ")
     respond_with(@artist)
   end
 
@@ -82,7 +82,7 @@ class ArtistsController < ApplicationController
     @artist.destroy
     respond_with(@artist) do |format|
       format.html do
-        redirect_to(artists_path, notice: @artist.valid? ? "Director deleted" : @artist.errors.full_messages.join("; "))
+        redirect_to(artists_path, notice: @artist.valid? ? tm("{{Artist}} deleted") : @artist.errors.full_messages.join("; "))
       end
     end
   end
@@ -124,7 +124,7 @@ class ArtistsController < ApplicationController
   end
 
   def ensure_can_edit(user)
-    raise(User::PrivilegeError, "Director is locked.") unless @artist.editable_by?(user)
+    raise(User::PrivilegeError, tm("{{Artist}} is locked.")) unless @artist.editable_by?(user)
   end
 
   def artist_params

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,27 +2,27 @@
 
 class StaticController < ApplicationController
   def privacy
-    @page_name = "e6ai:privacy_policy"
+    @page_name = tm("{{e621}}:privacy_policy")
     @page = format_wiki_page(@page_name)
   end
 
   def privacy_discordbot
-    @page_name = "e621:privacy_discordbot"
+    @page_name = tm("{{e621}}:privacy_discordbot")
     @page = format_wiki_page(@page_name)
   end
 
   def code_of_conduct
-    @page_name = "e6ai:rules"
+    @page_name = tm("{{e621}}:rules")
     @page = format_wiki_page(@page_name)
   end
 
   def contact
-    @page_name = "e6ai:contact"
+    @page_name = tm("{{e621}}:contact")
     @page = format_wiki_page(@page_name)
   end
 
   def takedown
-    @page_name = "e6ai:takedown"
+    @page_name = tm("{{e621}}:takedown")
     @page = format_wiki_page(@page_name)
   end
 
@@ -96,7 +96,7 @@ class StaticController < ApplicationController
     if request.post?
       redirect_to(Danbooru.config.discord_site, allow_other_host: true)
     else
-      @page_name = "e6ai:discord"
+      @page_name = tm("{{e621}}:discord")
       @page = format_wiki_page(@page_name)
     end
   end

--- a/app/controllers/terms_of_uses_controller.rb
+++ b/app/controllers/terms_of_uses_controller.rb
@@ -5,7 +5,7 @@ class TermsOfUsesController < ApplicationController
   before_action :admin_only, only: %i[clear_cache bump_version]
 
   def show
-    @page_name = "e6ai:terms_of_service"
+    @page_name = tm("{{e621}}:terms_of_service")
     @content = helpers.tos_content
     @version = Setting.tos_version
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
     @user = User.find(User.name_or_id_to_id_forced(params[:id]))
     @presenter = UserPresenter.new(@user)
 
-    @page = WikiPage.titled("e6ai:upload_limit").presence || WikiPage.new(body: "Wiki page \"e6ai:upload_limit\" not found.")
+    @page = WikiPage.titled(tm("{{e621}}:upload_limit")).presence || WikiPage.new(body: tm("Wiki page \"{{e621}}:upload_limit\" not found."))
     respond_with(@user, methods: @user.full_attributes)
   end
 

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -99,17 +99,17 @@ class ModActionDecorator < ApplicationDecorator
 
       ### Artist ###
     when "artist_delete"
-      "Deleted director ##{vals['artist_id']} (#{vals['artist_name']})"
+      tm("Deleted {{artist}} #%<artist_id>s (%<artist_name>s)", **vals.symbolize_keys)
     when "artist_page_rename"
-      "Renamed director page (\"#{vals['old_name']}\":/directors/show_or_new?name=#{vals['old_name']} → \"#{vals['new_name']}\":/directors/show_or_new?name=#{vals['new_name']})"
+      tm("Renamed {{artist}} page (\"%<old_name>s\":/{{artists}}/show_or_new?name=%<old_name>s → \"%<new_name>s\":/{{artists}}/show_or_new?name=%<new_name>s)", **vals.symbolize_keys)
     when "artist_page_lock"
-      "Locked director page director ##{vals['artist_page']}"
+      tm("Locked {{artist}} page {{artist}} #%<artist_page>s", **vals.symbolize_keys)
     when "artist_page_unlock"
-      "Unlocked director page director ##{vals['artist_page']}"
+      tm("Unlocked {{artist}} page {{artist}} #%<artist_page>s", **vals.symbolize_keys)
     when "artist_user_linked"
-      "Linked #{user} to director ##{vals['artist_page']}"
+      tm("Linked %<user>s to {{artist}} #%<artist_page>s", user: user, **vals.symbolize_keys)
     when "artist_user_unlinked"
-      "Unlinked #{user} from director ##{vals['artist_page']}"
+      tm("Unlinked %<user>s from {{artist}} #%<artist_page>s", user: user, **vals.symbolize_keys)
 
       ### Avoid Posting ###
     when "avoid_posting_create"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,7 @@ module ApplicationHelper
 
   def tos_content
     Cache.fetch("tos_content", expires_in: 1.day) do
-      wiki = WikiPage.titled("e6ai:terms_of_service")
+      wiki = WikiPage.titled(tm("{{e621}}:terms_of_service"))
       return "Terms of use not found." if wiki.nil?
       processed_body = replace_cross_domain_links(wiki.body)
       format_text(processed_body, allow_color: true)

--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -9,7 +9,7 @@ module ArtistsHelper
     else
       link = link_to(name, new_artist_path(artist: { name: name }))
       return link.html_safe if hide_new_notice
-      notice = tag.span("*", class: "new-artist", title: "No director with this name currently exists.")
+      notice = tag.span("*", class: "new-artist", title: tm("No {{artist}} with this name currently exists."))
       "#{link} #{notice}".html_safe
     end
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -73,7 +73,7 @@ module PostsHelper
       html << link_to(text, posts_path(:tags => "parent:#{post.parent_id}"))
     end
 
-    html << " (#{link_to('learn more', wiki_pages_path(title: 'e6ai:post_relationships'))}) "
+    html << " (#{link_to('learn more', wiki_pages_path(title: tm('{{e621}}:post_relationships')))}) "
 
     html << link_to("show »", "#", id: "has-parent-relationship-preview-link", data: { hotkey: "postrel" })
 
@@ -87,7 +87,7 @@ module PostsHelper
     text = children_post_set.children.count == 1 ? "1 child" : "#{children_post_set.children.count} children"
     html << link_to(text, posts_path(:tags => "parent:#{post.id}"))
 
-    html << " (#{link_to('learn more', wiki_pages_path(title: 'e6ai:post_relationships'))}) "
+    html << " (#{link_to('learn more', wiki_pages_path(title: tm('{{e621}}:post_relationships')))}) "
 
     html << link_to("show »", "#", id: "has-children-relationship-preview-link", data: { hotkey: "postrel" })
 

--- a/app/helpers/term_helper.rb
+++ b/app/helpers/term_helper.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module TermHelper
+  # Terms to translate in the UI, as a map.
+  # Example: `{ "e621": "myBooru" }``
+  # Supported terms: "e621", "artist", "an artist", "Artist", "artists", "Artists", "copyright",
+  # "Copyright", "copyrights", "Copyrights".
+  # This doesn't covert all usage of such terms but most of them (notably the .vue files).
+  TERMS = {
+    "e621": "e6ai",
+    "artist": "director",
+    "an artist": "a director",
+    "Artist": "Director",
+    "artists": "directors",
+    "Artists": "Directors",
+    "copyright": "franchise",
+    "Copyright": "Franchise",
+    "copyrights": "franchises",
+    "Copyrights": "Franchises",
+  }.freeze
+
+  CACHE = Concurrent::Map.new
+  MAX_CACHE_SIZE = 2048
+
+  def self.format(text, **vars)
+    unless text.frozen?
+      Rails.logger.error("Not a frozen string: \"#{text}\". Check that tm() is not being used on computed strings like templates.")
+      # Uncomment to better debug incorrect usage
+      raise "Not a frozen string: \"#{text}\""
+    end
+
+    processed = CACHE.compute_if_absent(text) do
+      text.gsub(/\{\{([\w ]+)\}\}/) do
+        (TERMS[$1.to_sym] || $1).freeze
+      end
+    end
+
+    if CACHE.size >= MAX_CACHE_SIZE
+      CACHE.clear
+      Rails.logger.warn("TermHelper cache exceeded #{MAX_CACHE_SIZE} entries and was purged. Check that tm() is not being used on computed strings like templates.")
+    end
+
+    vars.empty? ? processed : (processed % vars)
+  end
+end
+
+# Subsitutes terms in double braces (example: "{{artist}}") by their equivalents defined in
+# TermHelper.TERMS. Terms not found are unmodified (braces are removed). Supports standard string
+# formatting syntax. Do not call tm() on computed strings, this will bloat the cache. Use templating
+# instead. It's an error to call tm() on an unfrozen string.
+def tm(...)
+  TermHelper.format(...)
+end

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -11,7 +11,7 @@ class DbExportJob < ApplicationJob
   end
 
   EXPORTS = {
-    "directors" => {
+    tm("{{artists}}") => {
       query: read_export_sql("artists"),
     },
     "bulk_update_requests" => {

--- a/app/jobs/sitemap_generator_job.rb
+++ b/app/jobs/sitemap_generator_job.rb
@@ -78,7 +78,7 @@ class SitemapGeneratorJob < ApplicationJob
         # Generate media sitemaps for the included posts.
         included_posts.each do |post|
           post.inject_tag_categories(types)
-          artist_names = post.artist_tags.map(&:name).join(", ").presence || "unknown director"
+          artist_names = post.artist_tags.map(&:name).join(", ").presence || tm("unknown {{artist}}")
 
           if post.is_video?
             add "/posts/#{post.id}", lastmod: post.updated_at, videos: [{

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -36,7 +36,7 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
 
     # Build weighted function_score: base randomness + boosts for shared character/copyright tags
     character_tags = @post.tags_for_category("character").min_by(10, &:post_count).map(&:name)
-    copyright_tags = @post.tags_for_category("franchise").min_by(10, &:post_count).map(&:name)
+    copyright_tags = @post.tags_for_category(tm("{{copyright}}")).min_by(10, &:post_count).map(&:name)
     species_tags = @post.tags_for_category("species").min_by(10, &:post_count).map(&:name)
 
     functions = [{ random_score: { seed: @post.id, field: "id" } }]

--- a/app/logical/site_map.rb
+++ b/app/logical/site_map.rb
@@ -179,13 +179,13 @@ module SiteMap
   page :tools, :help_pages, "Help Index"
 
   # --- Artists ---
-  group :artists, "Directors"
+  group :artists, tm("{{Artists}}")
   page :artists, :artists, "Listing"
   page :artists, :artist_urls, "URLs"
   # page :artists, :avoid_postings, "Avoid Posting Entries"
   page :artists, :avoid_posting_static, "Avoid Posting List"
   page :artists, :artist_versions, "Changes"
-  page :artists, :help_page, "Help", params: { id: "artists" }
+  page :artists, :help_page, "Help", params: { id: tm("{{artists}}") }
 
   # --- Tags ---
   group :tags, "Tags"

--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -4,15 +4,14 @@ class TagCategory
   MAPPING = {
     "general" => 0,
     "gen" => 0,
-    "director" => 1,
-    "direct" => 1,
-    "dir" => 1,
+    tm("{{artist}}") => 1,
+    tm("{{artist}}")[..2] => 1,
     "contributor" => 2,
     "contrib" => 2,
     "cont" => 2,
-    "franchise" => 3,
-    "franc" => 3,
-    "fr" => 3,
+    tm("{{copyright}}") => 3,
+    tm("{{copyright}}")[..3] => 3,
+    tm("{{copyright}}")[..1] => 3,
     "character" => 4,
     "char" => 4,
     "ch" => 4,
@@ -28,9 +27,9 @@ class TagCategory
 
   CANONICAL_MAPPING = {
     "General" => 0,
-    "Director" => 1,
+    tm("{{Artist}}") => 1,
     "Contributor" => 2,
-    "Franchise" => 3,
+    tm("{{Copyright}}") => 3,
     "Character" => 4,
     "Species" => 5,
     "Invalid" => 6,
@@ -38,14 +37,21 @@ class TagCategory
     "Lore" => 8,
   }.freeze
 
-  MEMBER_EDITABLE_CATEGORIES = %w[General Director Contributor Franchise Character Species].freeze
+  MEMBER_EDITABLE_CATEGORIES = [
+    "General",
+    tm("{{Artist}}"),
+    "Contributor",
+    tm("{{Copyright}}"),
+    "Character",
+    "Species",
+  ].freeze
   MEMBER_EDITABLE_MAPPING = CANONICAL_MAPPING.select { |k, _| MEMBER_EDITABLE_CATEGORIES.include?(k) }.freeze
 
   REVERSE_MAPPING = {
     0 => "general",
-    1 => "director",
+    1 => tm("{{artist}}"),
     2 => "contributor",
-    3 => "franchise",
+    3 => tm("{{copyright}}"),
     4 => "character",
     5 => "species",
     6 => "invalid",
@@ -70,9 +76,9 @@ class TagCategory
 
   SHORT_NAME_MAPPING = {
     "gen" => "general",
-    "dir" => "director",
+    "dir" => tm("{{artist}}"),
     "cont" => "contributor",
-    "franc" => "franchise",
+    "franc" => tm("{{copyright}}"),
     "char" => "character",
     "spec" => "species",
     "inv" => "invalid",
@@ -82,9 +88,9 @@ class TagCategory
 
   HEADER_MAPPING = {
     "general" => "General",
-    "director" => "Director",
+    tm("{{artist}}") => tm("{{Artist}}"),
     "contributor" => "Contributors",
-    "franchise" => "Franchises",
+    tm("{{copyright}}") => tm("{{Copyrights}}"),
     "character" => "Characters",
     "species" => "Species",
     "invalid" => "Invalid",
@@ -94,9 +100,9 @@ class TagCategory
 
   ADMIN_ONLY_MAPPING = {
     "general" => false,
-    "director" => false,
+    tm("{{artist}}") => false,
     "contributor" => false,
-    "franchise" => false,
+    tm("{{copyright}}") => false,
     "character" => false,
     "species" => false,
     "invalid" => true,
@@ -105,13 +111,13 @@ class TagCategory
   }.freeze
 
   HUMANIZED_MAPPING = {
-    "director" => {
+    tm("{{artist}}") => {
       "slice" => 0,
       "exclusion" => [],
       "regexmap" => //,
       "formatstr" => "directed by %s",
     },
-    "franchise" => {
+    tm("{{copyright}}") => {
       "slice" => 1,
       "exclusion" => [],
       "regexmap" => //,
@@ -125,13 +131,47 @@ class TagCategory
     },
   }.freeze
 
-  CATEGORIES = %w[general species character franchise director contributor invalid lore meta].freeze
+  CATEGORIES = [
+    "general",
+    "species",
+    "character",
+    tm("{{copyright}}"),
+    tm("{{artist}}"),
+    "contributor",
+    "invalid",
+    "lore",
+    "meta",
+  ].freeze
   CATEGORY_IDS = CANONICAL_MAPPING.values.freeze
 
   SHORT_NAME_LIST = SHORT_NAME_MAPPING.keys.freeze
-  HUMANIZED_LIST = %w[character franchise director].freeze
-  SPLIT_HEADER_LIST = %w[invalid director contributor franchise character species general meta lore].freeze
-  CATEGORIZED_LIST = %w[invalid director contributor franchise character species meta general lore].freeze
+  HUMANIZED_LIST = [
+    "character",
+    tm("{{copyright}}"),
+    tm("{{artist}}"),
+  ].freeze
+  SPLIT_HEADER_LIST = [
+    "invalid",
+    tm("{{artist}}"),
+    "contributor",
+    tm("{{copyright}}"),
+    "character",
+    "species",
+    "general",
+    "meta",
+    "lore",
+  ].freeze
+  CATEGORIZED_LIST = [
+    "invalid",
+    tm("{{artist}}"),
+    "contributor",
+    tm("{{copyright}}"),
+    "character",
+    "species",
+    "meta",
+    "general",
+    "lore",
+  ].freeze
 
   SHORT_NAME_REGEX = SHORT_NAME_LIST.join("|").freeze
   ALL_NAMES_REGEX = MAPPING.keys.join("|").freeze

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -311,7 +311,7 @@ class Artist < ApplicationRecord
 
     def revert_to!(version)
       if id != version.artist_id
-        raise RevertError.new("You cannot revert to a previous version of another director.")
+        raise RevertError.new(tm("You cannot revert to a previous version of another {{artist}}."))
       end
 
       self.name = version.name
@@ -382,7 +382,7 @@ class Artist < ApplicationRecord
 
     def categorize_tag
       if new_record? || saved_change_to_name?
-        Tag.find_or_create_by_name("director:#{name}")
+        Tag.find_or_create_by_name(tm("{{artist}}:%<name>s", name: name))
       end
     end
   end
@@ -402,7 +402,7 @@ class Artist < ApplicationRecord
       return if CurrentUser.is_staff?
 
       if is_locked?
-        errors.add(:base, "Director is locked")
+        errors.add(:base, tm("{{Artist}} is locked"))
         throw :abort
       end
     end
@@ -516,9 +516,9 @@ class Artist < ApplicationRecord
 
   module AvoidPostingMethods
     def validate_protected_properties_not_changed
-      errors.add(:name, "cannot be changed while the director is on the avoid posting list") if will_save_change_to_name?
-      errors.add(:group_name, "cannot be changed while the director is on the avoid posting list") if will_save_change_to_group_name?
-      errors.add(:other_names, "cannot be changed while the director is on the avoid posting list") if will_save_change_to_other_names?
+      errors.add(:name, tm("cannot be changed while the {{artist}} is on the avoid posting list")) if will_save_change_to_name?
+      errors.add(:group_name, tm("cannot be changed while the {{artist}} is on the avoid posting list")) if will_save_change_to_group_name?
+      errors.add(:other_names, tm("cannot be changed while the {{artist}} is on the avoid posting list")) if will_save_change_to_other_names?
       throw(:abort) if errors.any?
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,7 +8,11 @@ class Post < ApplicationRecord
   # Tags to copy when copying notes.
   NOTE_COPY_TAGS = %w[translated partially_translated translation_check translation_request].freeze
   NON_ARTIST_TAGS = %w[avoid_posting conditional_dnp epilepsy_warning sound_warning].freeze
-  NON_KNOWN_ARTIST_TAGS = %w[unknown_director anonymous_director third-party_edit].freeze
+  NON_KNOWN_ARTIST_TAGS = [
+    tm("unknown_{{artist}}"),
+    tm("anonymous_{{artist}}"),
+    "third-party_edit",
+  ].freeze
 
   # Seconds of age worth one log10 unit of score in the `order:hot` ranking (~5 days).
   # Smaller favours fresher posts; larger lets posts stay hot longer.
@@ -2118,7 +2122,7 @@ class Post < ApplicationRecord
 
       new_artist_tags.each do |tag|
         if tag.artist.blank?
-          warnings.add(:base, "Director [[#{tag.name}]] requires an director entry. \"Create new director entry\":[/artists/new?artist%5Bname%5D=#{CGI.escape(tag.name)}]")
+          warnings.add(:base, tm("{{Artist}} [[%<tag_name>s]] requires {{an artist}} entry. \"Create new {{artist}} entry\":[/{{artists}}/new?artist%%5Bname%%5D=%<escaped_tag_name>s]", tag_name: tag.name, escaped_tag_name: CGI.escape(tag.name)))
         end
       end
     end
@@ -2139,14 +2143,14 @@ class Post < ApplicationRecord
       return if !new_record?
       return if tags.any? { |t| t.category == Tag.categories.artist }
 
-      self.warnings.add(:base, 'Director tag is required. "Click here":/help/tags#catchange if you need help changing the category of an tag. Ask on the forum if you need naming help')
+      self.warnings.add(:base, tm("{{Artist}} tag is required. \"Click here\":/help/tags#catchange if you need help changing the category of an tag. Ask on the forum if you need naming help"))
     end
 
     def has_enough_tags
       return if !new_record?
 
       if tags.count {|t| t.category == Tag.categories.general} < 10
-        self.warnings.add(:base, "Uploads must have at least 10 general tags. Read [[e6ai:tags]] for guidelines on tagging your uploads")
+        self.warnings.add(:base, tm("Uploads must have at least 10 general tags. Read [[{{e621}}:tags]] for guidelines on tagging your uploads"))
       end
     end
   end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -144,7 +144,7 @@ class PostPresenter < Presenter
         type_tags = type_tags.map { |tag| tag.match(regexmap)[1] }
       end
 
-      if category == "franchise" && @post.tags_for_category("character").blank?
+      if category == tm("{{copyright}}") && @post.tags_for_category("character").blank?
         type_tags.to_sentence
       else
         formatstr % type_tags.to_sentence

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -1,7 +1,7 @@
 <div id="c-artist-urls">
   <div id="a-index">
     <%= form_search(path: artist_urls_path) do |f| %>
-      <%= f.input :artist_name, label: "Director Name", autocomplete: "artist" %>
+      <%= f.input :artist_name, label: tm("{{Artist}} Name"), autocomplete: "artist" %>
       <%= f.input :url_matches, label: "URL" %>
       <%= f.input :normalized_url_matches, label: "Normalized URL" %>
       <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
@@ -12,7 +12,7 @@
       <thead>
         <tr>
           <th>ID</th>
-          <th>Director Name</th>
+          <th><%= tm("{{Artist}} Name") %></th>
           <th>URL</th>
           <th>Normalized URL</th>
           <th>Active?</th>
@@ -42,5 +42,5 @@
 <%= render "artists/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Director URLs
+  <%= tm("{{Artist}} URLs") %>
 <% end %>

--- a/app/views/artist_versions/index.html.erb
+++ b/app/views/artist_versions/index.html.erb
@@ -1,6 +1,6 @@
 <div id="c-artist-versions">
   <div id="a-index">
-    <h1>Director History</h1>
+    <h1><%= tm("{{Artist}} History") %></h1>
 
     <%= render "search" %>
     <%= render "standard_listing" %>
@@ -11,5 +11,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Director Versions
+  <%= tm("{{Artist}} Versions") %>
 <% end %>

--- a/app/views/artist_versions/search.html.erb
+++ b/app/views/artist_versions/search.html.erb
@@ -9,5 +9,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Director Changes
+  <%= tm("{{Search {{Artist}} Changes") %>
 <% end %>

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -7,7 +7,7 @@
   <% else %>
     <p><%= @artist.name %></p>
     <% if @artist.dnp_restricted? %>
-      <p>Name, other names, and group name cannot be edited for directors on the <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</p>
+      <p><%= tm("Name, other names, and group name cannot be edited for {{artists}} on the") %> <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</p>
     <% end %>
   <% end %>
   <% if CurrentUser.is_staff? %>
@@ -21,7 +21,7 @@
   <%= f.input :url_string, label: "URLs", as: :text, input_html: { size: "80x10", value: params.dig(:artist, :url_string) || @artist.urls.join("\n")}, hint: "You can prefix a URL with - to mark it as dead." %>
 
   <% if @artist.is_note_locked? %>
-    <p>Director is note locked. Notes cannot be edited.</p>
+    <p><%= tm("{{Artist}} is note locked. Notes cannot be edited.") %></p>
   <% end %>
   <%= f.input :notes, as: :dtext, limit: Danbooru.config.wiki_page_max_size, disabled: @artist.is_note_locked?, allow_color: true %>
   <%= f.button :submit, "Submit" %>

--- a/app/views/artists/_quick_search.html.erb
+++ b/app/views/artists/_quick_search.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(artists_path, :method => :get) do %>
-  <%= text_field "search", "any_name_or_url_matches", id: "quick_search_name", placeholder: "Search directors", "data-autocomplete": "artist" %>
+  <%= text_field "search", "any_name_or_url_matches", id: "quick_search_name", placeholder: tm("Search {{artists}}"), "data-autocomplete": "artist" %>
 <% end %>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <%= subnav_link_to "Recent changes", artist_versions_path %>
   <%= subnav_link_to "URLs", artist_urls_path %>
-  <%= subnav_link_to "Help", help_page_path(id: "directors") %>
+  <%= subnav_link_to "Help", help_page_path(id: tm("{{artists}}")) %>
   <% if @artist && !@artist.new_record? %>
     <li class="divider"></li>
     <%= subnav_link_to "Posts (#{@artist.tag.try(:post_count).to_i})", posts_path(tags: @artist.name) %>
@@ -17,7 +17,7 @@
     <% end %>
     <%= subnav_link_to "History", artist_versions_path(search: { artist_id: @artist.id }), data: { hotkey: "history" } %>
     <% if @artist.deletable_by?(CurrentUser.user) %>
-      <%= subnav_link_to "Delete", artist_path(@artist), method: :delete, data: { confirm: "Are you sure you want to delete this director? This cannot be undone." } %>
+      <%= subnav_link_to "Delete", artist_path(@artist), method: :delete, data: { confirm: tm("Are you sure you want to delete this {{artist}}? This cannot be undone.") } %>
     <% end %>
     <% if @artist.is_dnp? %>
       <li class="divider"></li>

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -1,7 +1,7 @@
 <div id="c-artists">
   <div id="a-show">
     <h1>
-      Director: <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_id}" %>
+      <%= tm("{{Artist}}: ") %> <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_id}" %>
       <% if @artist.is_locked? %>
         (locked)
       <% end %>
@@ -14,7 +14,7 @@
           <% if @artist.avoid_posting.pretty_details.present? %>
             <%= format_text(@artist.avoid_posting.pretty_details, inline: true) %>
           <% else %>
-            Do not upload artwork created by this director.
+            <%= tm("Do not upload artwork created by this {{artist}}.") %>
           <% end %>
         </div>
         <% if CurrentUser.is_staff? && @artist.avoid_posting.staff_notes.present? %>
@@ -56,5 +56,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Director - <%= @artist.name %>
+  <%= tm("{{Artist}} - %<name>s", name: @artist.name) %>
 <% end %>

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -42,7 +42,7 @@
   <% if CurrentUser.user.is_staff? %>
     <li><strong>Other</strong></li>
     <ul>
-      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Director: #{artist.name} #{Date.current}" }) %></li>
+      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: tm("{{Artist}}: %<name>s %<date>s", name: artist.name, date: Date.current) }) %></li>
     </ul>
   <% end %>
 </ul>

--- a/app/views/artists/edit.html.erb
+++ b/app/views/artists/edit.html.erb
@@ -1,12 +1,12 @@
 <div id="c-artists">
   <div id="a-edit">
-    <h1>Edit Director</h1>
+    <h1><%= tm("Edit {{Artist}}") %></h1>
 
     <% if @artist.editable_by?(CurrentUser.user) %>
       <%= render "form" %>
 
     <% elsif @artist.is_locked? %>
-      <p>This director entry is locked and cannot be edited.</p>
+      <p><%= tm("This {{artist}} entry is locked and cannot be edited.") %></p>
 
     <% end %>
   </div>
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Director - <%= @artist.name %>
+  <%= tm("Edit {{Artist}} - %<name>s", name: @artist.name) %>
 <% end %>

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -32,5 +32,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Directors
+  <%= tm("{{Artists}}") %>
 <% end %>

--- a/app/views/artists/new.html.erb
+++ b/app/views/artists/new.html.erb
@@ -1,6 +1,6 @@
 <div id="c-artists">
   <div id="a-new">
-    <h1>New Director</h1>
+    <h1><%= tm("New {{Artist}}") %></h1>
 
     <%= error_messages_for :artist %>
 
@@ -11,5 +11,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Director
+  <%= tm("New {{Artist}}") %>
 <% end %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -4,7 +4,7 @@
       <%= render "summary", artist: @artist %>
     </div>
   <% else %>
-    <p>The director requested removal of this page.</p>
+    <p><%= tm("The {{artist}} requested removal of this page.") %></p>
   <% end %>
 <% end %>
 

--- a/app/views/artists/show_or_new.html.erb
+++ b/app/views/artists/show_or_new.html.erb
@@ -1,5 +1,5 @@
 <%= render layout: "show" do %>
   <div>
-    <p>This director entry does not exist. <%= link_to "Create new director entry", new_artist_path(artist: { name: params[:name] }) %>.</p>
+    <p><%= tm("This {{artist}} entry does not exist.") %> <%= link_to tm("Create new {{artist}} entry"), new_artist_path(artist: { name: params[:name] }) %>.</p>
   </div>
 <% end %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -7,7 +7,7 @@
       <h4 class="author-name">
         <%= link_to_user comment.creator %>
         <% if !post.nil? %>
-          <%= svg_icon(:chexagon, class: "chexagon", title: "Comment by a director on this post") if post.linked_users.include?(comment.creator_id) %>
+          <%= svg_icon(:chexagon, class: "chexagon", title: tm("Comment by {{an artist}} on this post")) if post.linked_users.include?(comment.creator_id) %>
         <% end %>
       </h4>
       <%= user_level_plain(comment.creator) %>

--- a/app/views/layouts/_favicon.html.erb
+++ b/app/views/layouts/_favicon.html.erb
@@ -6,6 +6,6 @@
 
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#1F1F1F">
-<meta name="apple-mobile-web-app-title" content="e6ai" />
+<meta name="apple-mobile-web-app-title" content=<%= tm("{{e621}}") %>/>
 
 <link rel="manifest" href="/manifest.json">

--- a/app/views/layouts/navigation/_main_links.html.erb
+++ b/app/views/layouts/navigation/_main_links.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <%= decorated_nav_link_to("Profile", :user, user_path(CurrentUser.user), class: "nav-hidden") %>
 <% end %>
-<%= decorated_nav_link_to("Directors", :brush, artists_path) %>
+<%= decorated_nav_link_to(tm("{{Artists}}"), :brush, artists_path) %>
 <%= decorated_nav_link_to("Posts", :images, posts_path) %>
 <%= decorated_nav_link_to("Pools", :library, gallery_pools_path) %>
 <%= decorated_nav_link_to("Sets", :group, post_sets_path) %>

--- a/app/views/mascots/_form.html.erb
+++ b/app/views/mascots/_form.html.erb
@@ -5,8 +5,8 @@
   <%= f.input :background_color %>
   <%= f.input :foreground_color %>
   <%= f.input :is_layered, label: "Layered", as: :boolean, hint: "The mascot image will be layered above the search form." %>
-  <%= f.input :artist_url, label: "Director URL" %>
-  <%= f.input :artist_name, label: "Director Name" %>
+  <%= f.input :artist_url, label: tm("{{Artist}} URL") %>
+  <%= f.input :artist_name, label: tm("{{Artist}} Name") %>
   <%= f.input :available_on_string, label: "Available on", hint: "Separated by a comma, don't include spaces before/after" %>
   <%= f.input :active %>
   <%= f.submit %>

--- a/app/views/mascots/index.html.erb
+++ b/app/views/mascots/index.html.erb
@@ -9,8 +9,8 @@
           <th>Name</th>
           <th>Background Color</th>
           <th>Foreground Color</th>
-          <th>Director Name</th>
-          <th>Director URL</th>
+          <th><%= tm("{{Artist}} Name") %></th>
+          <th><%= tm("{{Artist}} URL") %></th>
           <th>Active</th>
           <th>Available on</th>
           <th>Created</th>

--- a/app/views/notes/_dialog.html.erb
+++ b/app/views/notes/_dialog.html.erb
@@ -3,7 +3,7 @@
     <textarea id="note-editor-input" rows="6" placeholder="Enter note content here..."></textarea>
     <div class="note-editor-help">
       <span class="hint">All text is formatted using <a href="/help/dtext" target="_blank" rel="noopener" tabindex="-1">DText</a></span>
-      <span class="hint"><a href="/wiki_pages/e6ai:notes">Note Help</a></span>
+      <span class="hint"><a href=<%= tm("/wiki_pages/{{e621}}:notes") %>>Note Help</a></span>
     </div>
   </div>
 

--- a/app/views/pools/index.html.erb
+++ b/app/views/pools/index.html.erb
@@ -42,5 +42,5 @@
 <% end %>
 
 <% content_for(:html_header) do %>
-  <meta name="description" content="Pools are groups of posts with something in common. The most common use of pools is for posts that are part of a series (such as a comic, or a group of images released by a director).">
+  <meta name="description" content=<%= tm("Pools are groups of posts with something in common. The most common use of pools is for posts that are part of a series (such as a comic, or a group of images released by {{an artist}}).") %>>
 <% end %>

--- a/app/views/pools/new.html.erb
+++ b/app/views/pools/new.html.erb
@@ -2,7 +2,7 @@
   <div id="c-new">
     <h2>New Pool</h2>
 
-    <p style="font-weight: bold;">Before creating a pool, read the <%= link_to "pool guidelines", wiki_page_path(:id => "e6ai:pools") %>.</p>
+    <p style="font-weight: bold;">Before creating a pool, read the <%= link_to "pool guidelines", wiki_page_path(:id => tm("{{e621}}:pools")) %>.</p>
 
     <%= custom_form_for(@pool) do |f| %>
       <%= f.input :name, :as => :string, :required => true %>

--- a/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
+++ b/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
@@ -24,7 +24,7 @@
     <span class="tag-list-name">
       <%= tag.name.tr("_", " ") %>
       <% if post.present? && post.uploader_linked_artists.include?(tag.name) %>
-        <%= svg_icon(:chexagon, class: "chexagon", title: "Uploaded by the director") %>
+        <%= svg_icon(:chexagon, class: "chexagon", title: tm("Uploaded by the {{artist}}")) %>
       <% end %>
     </span>
 

--- a/app/views/posts/partials/show/content/_edit.html.erb
+++ b/app/views/posts/partials/show/content/_edit.html.erb
@@ -7,7 +7,7 @@
 
   <% unless CurrentUser.user.is_staff? %>
     <div style="margin-bottom: 0.5rem;">
-      <p>Before editing, read the <%= link_to "how to tag guide", wiki_page_path(id: "e6ai:tags") %>.</p>
+      <p>Before editing, read the <%= link_to "how to tag guide", wiki_page_path(id: tm("{{e621}}:tags")) %>.</p>
     </div>
   <% end %>
 

--- a/app/views/posts/partials/show/content/notices/_avoid_posting.html.erb
+++ b/app/views/posts/partials/show/content/notices/_avoid_posting.html.erb
@@ -13,7 +13,7 @@
               <span class="artist">
               <%= link_to dnp.artist_name, avoid_posting_path(dnp) %>
                 <% if dnp.artist.try(:linked_user_id) == post.uploader_id %>
-                  <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to this director.") %>
+                  <%= svg_icon(:chexagon, class: "chexagon", title: tm("The uploader is linked to this {{artist}}.")) %>
                 <% end %>
               </span>
               <span class="separator">-</span>

--- a/app/views/posts/partials/show/sidebar/_information.html.erb
+++ b/app/views/posts/partials/show/sidebar/_information.html.erb
@@ -81,7 +81,7 @@
     <li>
       Uploader: <%= link_to_user(post.uploader) %> <%= render(UserFeedbackComponent.new(user: post.uploader, style: :inline)) if CurrentUser.is_staff? %>
       <% if post.uploader_linked_artists.any? %>
-        <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to one of the director tags") %>
+        <%= svg_icon(:chexagon, class: "chexagon", title: tm("The uploader is linked to one of the {{artist}} tags")) %>
       <% end %>
     </li>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -137,7 +137,7 @@
               data-action="artist"
               aria-controls="post-recommendations-list"
               aria-selected="true"
-            >From the Director</button>
+            ><%= tm("From the {{Artist}}") %></button>
             <% end %>
             <% if tags_tab_available %>
             <button

--- a/app/views/staff/moderator_dashboards/_activity_artist.html.erb
+++ b/app/views/staff/moderator_dashboards/_activity_artist.html.erb
@@ -1,5 +1,5 @@
 <table class="striped">
-  <caption>Director Updates</caption>
+  <caption><%= tm("{{Artist}} Updates") %></caption>
   <thead>
     <tr>
       <th>User</th>

--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <%= f.input :profile_about, as: :dtext, label: "About", limit: Danbooru.config.user_about_max_size, allow_color: true %>
-      <%= f.input :profile_artinfo, as: :dtext, label: "Director Info", limit: Danbooru.config.user_about_max_size, allow_color: true %>
+      <%= f.input :profile_artinfo, as: :dtext, label: tm("{{Artist}} Info"), limit: Danbooru.config.user_about_max_size, allow_color: true %>
       <%= f.input :custom_title, input_html: { size: 50 }, hint: "Replaces the level badge text. Leave blank to show level." %>
       <%= f.input :base_upload_limit %>
 

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -91,9 +91,10 @@
       <%= render "percentage_table", header_title: "Tags", data: [
           ["Tag count", "total_tags"],
           ["General tag count", "general_tags", "total_tags"],
-          ["Director tag count", "director_tags", "total_tags"],
+          [tm("{{Artist}} tag count"), tm("{{artist}}_tags"), "total_tags"],
           ["Contributor tag count", "contributor_tags", "total_tags"],
           ["Character tag count", "character_tags", "total_tags"],
+          [tm("{{Copyright}} tag count"), tm("{{copyright}}_tags"), "total_tags"],
           ["Species tag count", "species_tags", "total_tags"],
           ["Meta tag count", "meta_tags", "total_tags"],
           ["Invalid tag count", "invalid_tags", "total_tags"],

--- a/app/views/tag_aliases/show.html.erb
+++ b/app/views/tag_aliases/show.html.erb
@@ -33,8 +33,8 @@
       <% if @tag_alias.consequent_tag&.artist&.is_dnp? || @tag_alias.antecedent_tag&.artist&.is_dnp? %>
         <li>
           <br />
-          <strong>Note:</strong> This tag alias is associated with a DNP director.<br />
-          Please check the <%= link_to "director page", artist_path(@tag_alias.consequent_tag&.artist || @tag_alias.antecedent_tag&.artist) %> for more information.
+          <strong>Note:</strong> <%= tm("This tag alias is associated with a DNP {{artist}}.") %><br />
+          Please check the <%= link_to tm("{{artist}} page"), artist_path(@tag_alias.consequent_tag&.artist || @tag_alias.antecedent_tag&.artist) %> for more information.
         </li>
       <% end %>
 
@@ -44,9 +44,9 @@
           <strong>Linked User</strong>: <%= link_to_user @tag_alias.antecedent_tag.artist.linked_user %>
           <br />
           <% if @tag_alias.consequent_tag&.artist.blank? %>
-            <strong>Note:</strong> Antecedent director page will be renamed to match the consequent tag upon approval.
+            <strong>Note:</strong> <%= tm("Antecedent {{artist}} page will be renamed to match the consequent tag upon approval.") %>
           <% elsif @tag_alias.consequent_tag&.artist&.linked_user_id.present? %>
-            <strong>Note:</strong> Consequent director tag also has a linked user: <%= link_to_user @tag_alias.consequent_tag.artist.linked_user %>
+            <strong>Note:</strong> <%= tm("Consequent {{artist}} tag also has a linked user:") %> <%= link_to_user @tag_alias.consequent_tag.artist.linked_user %>
           <% else %>
             <strong>Note:</strong> Linked user will be transferred to the consequent tag upon approval.
           <% end %>

--- a/app/views/tag_implications/show.html.erb
+++ b/app/views/tag_implications/show.html.erb
@@ -21,8 +21,8 @@
       <% if @tag_implication.consequent_tag&.artist&.is_dnp? || @tag_implication.antecedent_tag&.artist&.is_dnp? %>
         <li>
           <br />
-          <strong>Note:</strong> This tag alias is associated with a DNP director.<br />
-          Please check the <%= link_to "director page", artist_path(@tag_implication.consequent_tag&.artist || @tag_implication.antecedent_tag&.artist) %> for more information.
+          <strong>Note:</strong> <%= tm("This tag alias is associated with a DNP {{artist}}.") %><br />
+          Please check the <%= link_to tm("{{artist}} page"), artist_path(@tag_implication.consequent_tag&.artist || @tag_implication.antecedent_tag&.artist) %> for more information.
         </li>
       <% end %>
     </ul>

--- a/app/views/tags/_alias_and_implication_list.html.erb
+++ b/app/views/tags/_alias_and_implication_list.html.erb
@@ -2,24 +2,24 @@
 <% if tag&.antecedent_alias %>
   <p class="hint">
     This tag has been aliased to <%= link_to_wiki_or_new(tag.antecedent_alias.consequent_name) %>
-    (<%= link_to "learn more", wiki_pages_path(title: "e6ai:tag_aliases") %>).
+    (<%= link_to "learn more", wiki_pages_path(title: tm("{{e621}}:tag_aliases")) %>).
   </p>
 <% end %>
 <% if tag&.consequent_aliases&.present? %>
   <p class="hint">
     The following tags are aliased to this tag: <%= multiple_link_to_wiki_or_new(tag.consequent_aliases.map(&:antecedent_name).sort) %>
-    (<%= link_to "learn more", wiki_pages_path(title: "e6ai:tag_aliases") %>).
+    (<%= link_to "learn more", wiki_pages_path(title: tm("{{e621}}:tag_aliases")) %>).
   </p>
 <% end %>
 <% if tag&.antecedent_implications&.present? %>
   <p class="hint">
     This tag implicates <%= multiple_link_to_wiki_or_new(tag.antecedent_implications.map(&:consequent_name).sort) %>
-    (<%= link_to "learn more", wiki_pages_path(title: "e6ai:tag_implications") %>).
+    (<%= link_to "learn more", wiki_pages_path(title: tm("{{e621}}:tag_implications")) %>).
   </p>
 <% end %>
 <% if tag&.consequent_implications&.present? %>
   <p class="hint">
     The following tags implicate this tag: <%= multiple_link_to_wiki_or_new(tag.consequent_implications.map(&:antecedent_name).sort) %>
-    (<%= link_to "learn more", wiki_pages_path(title: "e6ai:tag_implications") %>).
+    (<%= link_to "learn more", wiki_pages_path(title: tm("{{e621}}:tag_implications")) %>).
   </p>
 <% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -3,6 +3,6 @@
   <%= f.input :category, label: "Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
   <%= f.input :order, collection: [%w[Count count], %w[Name name], %w[Newest date]], include_blank: false %>
   <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: "Any" %>
-  <%= f.input :has_artist, label: "Has director?", collection: %w[yes no], include_blank: true %>
+  <%= f.input :has_artist, label: tm("Has {{artist}}?"), collection: %w[yes no], include_blank: true %>
   <%= f.input :hide_empty, label: "Hide empty?", as: :boolean, default: true %>
 <% end %>

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -6,7 +6,7 @@
         <p>Your verification code is <span class='takedown-vericode'><%= @takedown.vericode %></span></p>
         <p>Your takedown request has been successfully created. Using the gallery account that you specified below as the "source", <span style="font-weight:bold;">please send your verification code via PM/note to</span>:</p>
 
-        <%= format_text(WikiPage.find_by(title: "e6ai:takedown_verification")&.body) %>
+        <%= format_text(WikiPage.find_by(title: tm("{{e621}}:takedown_verification"))&.body) %>
 
         <p>Once you send the verification code, we can process your takedown. This step is necessary in order to confirm that you are who you claim to be.</p>
         <p>Bookmark this page to be able to access your verification code later, as it will not appear when viewing the takedown otherwise.</p>

--- a/app/views/tickets/new_types/_post.html.erb
+++ b/app/views/tickets/new_types/_post.html.erb
@@ -41,7 +41,7 @@
     <input type="radio" name="ticket[report_reason]" value="takedown" class="report-reason-radio" id="post_report_reason_takedown" />
     <span class="report-reason-description">
       <b>Deletion Request</b>
-      <span>You are the director of this post, and would like to request its removal.</span>
+      <span><%= tm("You are the {{artist}} of this post, and would like to request its removal.") %></span>
     </span>
   </label>
 </div>
@@ -59,7 +59,7 @@
 
 <div class="report-reason report-unusual" id="report-reason-takedown" style="display: none;">
   <p>
-    Directors and character owners may request the permanent removal of their artwork by submitting a takedown request.<br />
+    <%= tm("{{Artists}} and character owners may request the permanent removal of their artwork by submitting a takedown request.") %><br />
     If you would like to replace this post with a better version, please upload the new version separately, and <a href="<%= new_post_flag_path(post_flag: { post_id: @post.id }) %>">flag this one as inferior</a>.
   </p>
 

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -11,7 +11,7 @@
       with? <%= link_to "Tagging Checklist", help_page_path(id: "tagging_checklist") %></p>
   </div>
   <div
-    id="uploader" 
+    id="uploader"
     data-compact-mode="<%= CurrentUser.compact_uploader? %>"
     data-safe-site="<%= CurrentUser.safe_mode? %>"
     data-upload-tags="<%= html_escape(CurrentUser.presenter.favorite_tags_with_types.to_json) %>"
@@ -26,7 +26,7 @@
   <% if CurrentUser.no_uploading? %>
     <div id="post-uploads-remaining" class="box-section section background-red">
       Your ability to upload posts had been manually disabled by a staff member.<br />
-      If you believe that this was done in error, <%= link_to "contact an admin", show_or_new_wiki_pages_path(title: "e6ai:staff") %> to have this situation resolved.
+      If you believe that this was done in error, <%= link_to "contact an admin", show_or_new_wiki_pages_path(title: tm("{{e621}}:staff")) %> to have this situation resolved.
     </div>
   <% elsif (!CurrentUser.upload_free? && CurrentUser.upload_slots <= 5) || CurrentUser.post_upload_throttle <= 5 %>
     <% @limit_pieces = CurrentUser.upload_slots_pieces %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -18,7 +18,7 @@
     <h3>
       Already have an account? <%= link_to "Sign In.", new_session_path %>
     </h3>
-    <p>Please, read the <a href="/wiki_pages/e6ai:rules">site rules</a> before making an account.</p>
+    <p>Please, read the <a href=<%= tm("/wiki_pages/{{e621}}:rules") %>>site rules</a> before making an account.</p>
     <p>You must confirm your email address, so you should only use one that you have access to.</p>
     <p>This site is open to web crawlers, meaning that almost everything is public.</p>
     <p>This includes your account name, favorites, uploads, and comments. Do not choose a name you don't want to be associated with.</p>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -89,8 +89,8 @@
   </tab-body>
 </tab-entry>
 
-<tab-entry tab="<%= tab_name %>" group="profile" class="bigtext" search="user profile director info">
-  <tab-head><%= form.label :profile_artinfo, "Director Info" %></tab-head>
+<tab-entry tab="<%= tab_name %>" group="profile" class="bigtext" search=<%= tm("user profile {{artist}} info") %>>
+  <tab-head><%= form.label :profile_artinfo, tm("{{Artist}} Info") %></tab-head>
   <tab-body>
     <%= form.input_field :profile_artinfo,
       as: :dtext,

--- a/app/views/users/partials/show/_about.html.erb
+++ b/app/views/users/partials/show/_about.html.erb
@@ -10,7 +10,7 @@
 
 <% if has_artinfo %>
   <tab-entry tab="artinfo" class="profile-readmore profile-artinfo-section flex">
-    <tab-head>Director Information</tab-head>
+    <tab-head><%= tm("{{Artist}} Information") %></tab-head>
     <tab-body class="content dtext-container">
       <%= format_text(user.profile_artinfo, allow_color: true) %>
       <button class="content-readmore">Show More</button>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -82,7 +82,7 @@
       <% if user.artist_version_count != 0 %>
         <a href="<%= artist_versions_path(search: { updater_id: user.id }) %>" class="entry">
           <h5><%= user.artist_version_count %></h5>
-          <span>Director</span>
+          <span><%= tm("{{Arist}}") %></span>
         </a>
       <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
         <button role="tab" name="about">About</button>
       <% end %>
       <% if has_artinfo %>
-        <button role="tab" name="artinfo">Director Info</button>
+        <button role="tab" name="artinfo"><%= tm("{{Artist}} Info") %></button>
       <% end %>
       <button role="tab" name="stats">Stats</button>
     </tabs-menu>

--- a/app/views/users/upload_limit.html.erb
+++ b/app/views/users/upload_limit.html.erb
@@ -22,7 +22,7 @@
       <% if is_current_user %>
         <p class="profile-notice">
           Your ability to upload posts had been manually disabled by a staff member.<br />
-          If you believe that this was done in error, <%= link_to "contact an admin", show_or_new_wiki_pages_path(title: "e6ai:staff") %> to have this situation resolved.
+          If you believe that this was done in error, <%= link_to "contact an admin", show_or_new_wiki_pages_path(title: tm("{{e621}}:staff")) %> to have this situation resolved.
         </p>
       <% end %>
     <% else %>
@@ -138,7 +138,7 @@
             </span>
           </span>
         </span>
-        
+
         <div class="upload-limit-explanation">
           <abbr title="Maximum Upload Slots" class="ul-num upl-max"><%= @user.upload_slots_max %></abbr>
           <div class="ul-exp">

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -39,7 +39,7 @@
         <% end %>
 
         <% if wiki_content.artist %>
-          <p><%= link_to "View director", show_or_new_artists_path(name: wiki_content.artist.name) %></p>
+          <p><%= link_to tm("View {{artist}}"), show_or_new_artists_path(name: wiki_content.artist.name) %></p>
         <% end %>
 
         <%= wiki_page_alias_and_implication_list(wiki_content) %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -20,7 +20,7 @@
       </div>
 
       <% if @wiki_page.tag&.category == Tag.categories.artist %>
-        <%= link_to("View director",  show_or_new_artists_path(name: @wiki_page.title)) %>
+        <%= link_to(tm("View {{artist}}"),  show_or_new_artists_path(name: @wiki_page.title)) %>
       <% end %>
 
       <%= wiki_page_alias_and_implication_list(@wiki_page)%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,8 @@ module Danbooru
     config.i18n.enforce_available_locales = false
     config.active_model.i18n_customize_full_message = true
 
+    config.action_view.frozen_string_literal = true
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,21 +14,21 @@ Rails.application.configure do
     # legacy CSP2 browsers that ignore strict-dynamic.
 
     # TODO: Temporarily disabled. Re-enable after resolving the issue with CF email obfuscation breaking upon the CSP.
-    policy.script_src :self, :strict_dynamic, "rv.e6ai.net", "https://www.google.com/recaptcha/", "https://www.gstatic.com/recaptcha/", "https://www.recaptcha.net/", "https://assets.freespeechcoalition.com", "https://op.dragonfru.it/"
+    policy.script_src :self, :strict_dynamic, "rv.#{Danbooru.config.domain}", "https://www.google.com/recaptcha/", "https://www.gstatic.com/recaptcha/", "https://www.recaptcha.net/", "https://assets.freespeechcoalition.com", "https://op.dragonfru.it/"
     policy.script_src(*policy.script_src, :unsafe_eval) if Rails.env.development?
 
     policy.style_src :self, :unsafe_inline
     policy.style_src(*policy.style_src, :unsafe_inline) if Rails.env.development?
 
-    policy.connect_src :self, "rv.e6ai.net", "op.dragonfru.it", "static1.e6ai.net", "api.freespeechcoalition.com"
+    policy.connect_src :self, "rv.#{Danbooru.config.domain}", "op.dragonfru.it", "static1.#{Danbooru.config.domain}", "api.freespeechcoalition.com"
     policy.connect_src(*policy.connect_src, "ws://localhost:3036", "http://localhost:3036", "http://host.docker.internal:8000") if Rails.env.development?
 
-    policy.object_src  :self, "static1.e6ai.net"
-    policy.media_src   :self, "static1.e6ai.net"
+    policy.object_src  :self, "static1.#{Danbooru.config.domain}"
+    policy.media_src   :self, "static1.#{Danbooru.config.domain}"
     policy.frame_ancestors :none
     policy.frame_src   "https://www.google.com/recaptcha/", "https://www.recaptcha.net/"
     policy.font_src    :self
-    policy.img_src     :self, :data, "static1.e6ai.net", "rv.e6ai.net"
+    policy.img_src     :self, :data, "static1.#{Danbooru.config.domain}", "rv.#{Danbooru.config.domain}"
     policy.child_src   :none
     policy.form_action :self
     # Specify URI for violation reports

--- a/db/populate.rb
+++ b/db/populate.rb
@@ -57,7 +57,7 @@ DEFAULT_PASSWORD = ENV.fetch("PASSWORD", "hexerade")
 CurrentUser.user = User.system
 
 def api_request(path)
-  response = Faraday.get("https://e6ai.net#{path}", nil, user_agent: "e621ng/seeding")
+  response = Faraday.get("https://#{Danbooru.config.domain}#{path}", nil, user_agent: "e621ng/seeding")
   JSON.parse(response.body)
 end
 
@@ -93,7 +93,7 @@ def populate_users(number, password: DEFAULT_PASSWORD)
         name: user_name,
         password_hash: "", # Required NOT NULL, but should be empty for bcrypt
         bcrypt_password_hash: encrypted_password,
-        email: "#{user_name}@e6ai.local",
+        email: tm("%<user_name>s@{{e621}}.local", user_name: user_name),
         created_at: created_at,
         updated_at: created_at,
         last_ip_addr: "127.0.0.1",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ admin = User.find_or_create_by!(name: "admin") do |user|
   user.password = "hexerade"
   user.password_confirmation = "hexerade"
   user.password_hash = ""
-  user.email = "admin@e621.local"
+  user.email = tm("admin@{{e621}}.local")
   user.can_approve_posts = true
   user.level = UserLevel::ADMIN
 
@@ -34,7 +34,7 @@ system = User.find_or_create_by!(name: Danbooru.config.system_user) do |user|
   user.password = "ae3n4oie2n3oi4en23oie4noienaorshtaioresnt"
   user.password_confirmation = "ae3n4oie2n3oi4en23oie4noienaorshtaioresnt"
   user.password_hash = ""
-  user.email = "system@e621.local"
+  user.email = tm("system@{{e621}}.local")
   user.can_approve_posts = true
   user.level = UserLevel::JANITOR
 end
@@ -49,7 +49,7 @@ ForumCategory.find_or_create_by!(name: "Tag Alias and Implication Suggestions") 
 end
 
 def api_request(path)
-  response = Faraday.get("https://e6ai.net#{path}", nil, user_agent: "e621ng/seeding")
+  response = Faraday.get("https://#{Danbooru.config.domain}#{path}", nil, user_agent: "e621ng/seeding")
   JSON.parse(response.body)
 end
 
@@ -71,7 +71,7 @@ end
 
 def setup_upload_whitelist
   UploadWhitelist.create do |entry|
-    entry.domain = "static1\.e6ai\.net" # rubocop:disable Style/RedundantStringEscape
+    entry.domain = tm("static1\.{{e621}}\.net") # rubocop:disable Style/RedundantStringEscape
   end
 end
 
@@ -83,7 +83,7 @@ def setup_flag_reasons
   PostFlagReason.create!(
     name: "uploading_guidelines",
     reason: "Does not meet the [[uploading_guidelines|uploading guidelines]]",
-    text: "This post fails to meet the site's standards, be it for artistic worth, image quality, relevancy, or something else.\nKeep in mind that your personal preferences have no bearing on this. If you find the content of a post objectionable, simply [[e621:blacklist|blacklist]] it.",
+    text: tm("This post fails to meet the site's standards, be it for artistic worth, image quality, relevancy, or something else.\nKeep in mind that your personal preferences have no bearing on this. If you find the content of a post objectionable, simply [[{{e621}}:blacklist|blacklist]] it."),
     needs_explanation: true,
     needs_staff_reason: true,
     target_date: Time.zone.local(2015, 1, 1),

--- a/spec/COMPATIBILITY.md
+++ b/spec/COMPATIBILITY.md
@@ -1,5 +1,7 @@
 # e621ng vs e6AI — Known Differences
 
+OUTDATED: most differences have been reverted or moved to configuration.
+
 This document records fork-specific divergences discovered while making the test suite
 portable across both codebases. Use it as a reference when writing new specs or porting
 changes between forks.

--- a/spec/decorators/mod_action_decorator_spec.rb
+++ b/spec/decorators/mod_action_decorator_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe ModActionDecorator do
     context "with artist actions" do
       it "artist_delete includes artist id and name" do
         desc = decorate("artist_delete", { "artist_id" => 3, "artist_name" => "someartist" }).format_description
-        expect(desc).to eq("Deleted director #3 (someartist)")
+        expect(desc).to eq("Deleted artist #3 (someartist)")
       end
 
       it "artist_page_rename includes old and new names" do

--- a/spec/jobs/db_export_job_spec.rb
+++ b/spec/jobs/db_export_job_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe DbExportJob do
 
       it "exports artists" do
         create(:artist, name: "test_export_artist")
-        expect(export_csv("directors")).to include("test_export_artist")
+        expect(export_csv("artists")).to include("test_export_artist")
       end
 
       it "exports post versions for visible changes" do

--- a/spec/logical/recommended_query_builder_spec.rb
+++ b/spec/logical/recommended_query_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RecommendedQueryBuilder do
       pool_ids: pool_ids,
     )
     allow(post).to receive(:tags_for_category) do |category|
-      pairs = { "character" => character_tags, "franchise" => copyright_tags, "species" => species_tags }
+      pairs = { "character" => character_tags, "copyright" => copyright_tags, "species" => species_tags }
       (pairs[category] || []).map { |name, count| instance_double(Tag, name: name, post_count: count, category_name: category) }
     end
     post

--- a/spec/models/avoid_posting/permissions_spec.rb
+++ b/spec/models/avoid_posting/permissions_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AvoidPosting do
       CurrentUser.user = create(:user)
       artist.name = "#{artist.name}_changed"
       expect(artist).not_to be_valid
-      expect(artist.errors[:name]).to include("cannot be changed while the director is on the avoid posting list")
+      expect(artist.errors[:name]).to include("cannot be changed while the artist is on the avoid posting list")
     end
 
     it "allows a bd_staff user to change the artist's name even with an active DNP" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,5 +120,11 @@ RSpec.configure do |config|
         reason.description = "The file contains either malicious code or contains a hidden file archive. This is not for imagery depicted in the image itself."
       end
     end
+
+    # Tests use the default terms
+    config.before do
+      stub_const("TermHelper::TERMS", {}.freeze)
+      TermHelper::CACHE.clear
+    end
   end
 end

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe StaticController do
   end
 
   describe "GET /static/privacy" do
-    include_examples "a wiki page action", "/static/privacy", "e6ai:privacy_policy"
+    include_examples "a wiki page action", "/static/privacy", "e621:privacy_policy"
   end
 
   describe "GET /static/privacy_discordbot", skip: "Not available in this fork" do
@@ -102,19 +102,19 @@ RSpec.describe StaticController do
   end
 
   describe "GET /static/code_of_conduct" do
-    include_examples "a wiki page action", "/static/code_of_conduct", "e6ai:rules"
+    include_examples "a wiki page action", "/static/code_of_conduct", "e621:rules"
   end
 
   describe "GET /static/contact" do
-    include_examples "a wiki page action", "/static/contact", "e6ai:contact"
+    include_examples "a wiki page action", "/static/contact", "e621:contact"
   end
 
   describe "GET /static/takedown" do
-    include_examples "a wiki page action", "/static/takedown", "e6ai:takedown"
+    include_examples "a wiki page action", "/static/takedown", "e621:takedown"
   end
 
   describe "GET /static/avoid_posting", skip: "Avoid postings routes not available in this fork" do
-    include_examples "a wiki page action", "/static/avoid_posting", "e6ai:avoid_posting_notice"
+    include_examples "a wiki page action", "/static/avoid_posting", "e621:avoid_posting_notice"
   end
 
   # ---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ RSpec.describe StaticController do
       context "when the wiki page exists" do
         before do
           CurrentUser.scoped(create(:admin_user)) do
-            create(:wiki_page, title: "e6ai:discord", body: "Join our Discord!")
+            create(:wiki_page, title: "e621:discord", body: "Join our Discord!")
           end
         end
 


### PR DESCRIPTION
_Obviously this would go upstream, but it makes more sense opening the WIP here to see how it would actually work in practice. I implemented a few example substitutions. Obviously I'll want some feedback on the idea before actually doing all the substitutions in e621ng._

Add a `TermHelper` to substitute matching templated terms with the ones preferred by the fork. You could achieve the same thing using I18n, but it needs a lot more changes since all affected strings need to be replaced with IDs and moved to a YAML file. This would remove a vast majority of the current changes in this fork, and coalesce them all into one `TERMS` hash. Substitutions are lazily evaluated and cached.